### PR TITLE
Disabled AE2 tools

### DIFF
--- a/config/AppliedEnergistics2/AppliedEnergistics2.cfg
+++ b/config/AppliedEnergistics2/AppliedEnergistics2.cfg
@@ -40,8 +40,8 @@ features {
     }
 
     toolsclassifications {
-        B:CertusQuartzTools=true
-        B:NetherQuartzTools=true
+        B:CertusQuartzTools=false
+        B:NetherQuartzTools=false
         B:PoweredTools=true
     }
 


### PR DESCRIPTION
Disabled AE2 quartz tool recipes. GT quartz tools can be still made.
