### PR TITLE
Create BigReactors.cfg

### DIFF
--- a/config/BigReactors.cfg
+++ b/config/BigReactors.cfg
@@ -1,0 +1,54 @@
+# Configuration file
+
+compatibility {
+    # If true, automatically adds all unregistered ingots found as clonesof standard yellorium fuel
+    B:autoAddUranium=false
+}
+
+
+general {
+    B:enableComedy=true
+    B:enableMetallurgyFantasyMetalsInTurbines=true
+    D:fuelUsageMultiplier=10.0
+    I:maxReactorHeight=48
+    I:maxReactorSize=32
+    I:maxTurbineHeight=32
+    I:maxTurbineSize=16
+    D:powerProductionMultiplier=0.6
+    B:registerCreativeMultiblockParts=true
+    I:ticksPerRedstoneUpdate=20
+    D:turbineAeroDragMultiplier=1.0
+    D:turbineCoilDragMultiplier=1.0
+    D:turbineFluidPerBladeMultiplier=1.0
+    D:turbineMassDragMultiplier=1.0
+}
+
+
+recipes {
+    B:enableCyaniteFromYelloriumRecipe=false
+    B:enableReactorPowerTapRecipe=false
+    B:registerCharcoalForSmelting=false
+    B:registerCoalForSmelting=false
+    B:registerGraphiteCharcoalCraftingRecipes=false
+    B:registerGraphiteCoalCraftingRecipes=false
+    B:registerYelloriteSmeltToUranium=false
+    B:registerYelloriumAsUranium=false
+    B:requireObsidianGlass=false
+    B:requireSteelInsteadOfIron=false
+}
+
+
+worldgen {
+    B:GenerateYelloriteOre=true
+    I:MaxYelloriteClustersPerChunk=5
+    I:MaxYelloriteOrePerCluster=10
+    I:YelloriteDimensionBlacklist <
+     >
+    I:YelloriteMaxY=50
+    B:enableWorldGen=true
+    B:enableWorldGenInNegativeDims=false
+    B:enableWorldRegeneration=false
+    I:userWorldGenVersion=0
+}
+
+


### PR DESCRIPTION
This file goes along with bigreactors.zs . I like the Steam Turbine, but not the reactor. It's not really "nuclear". Here are the key settings:

```
B:autoAddUranium=false

# with a Gold coil, the best available in this pack (GT 5 removed all its cool blocks !!), Steam Turbine is 2x as efficient as RC steam engines, taking 40 mB/t and turning it into 16 MJ/t vs. RC's 8 MJ/t for the same steam
D:powerProductionMultiplier=0.6

# This disables power output from the Reactor
B:enableCyaniteFromYelloriumRecipe=false
B:enableReactorPowerTapRecipe=false

 # This makes using the reactor as a steam generator very, very expensive
D:fuelUsageMultiplier=10.0
```
