### PR TITLE
Update HARD.conf

### DIFF
--- a/config/forestry/gamemodes/HARD.conf
+++ b/config/forestry/gamemodes/HARD.conf
@@ -37,28 +37,28 @@ fermenter.value.fertilizer=56
 # modifies the amount of biomass per cycle a fermenter will produce using compost.
 fermenter.value.compost=48
 # modifies the base amount of biomass a sapling will yield in a fermenter, affected by sappiness trait. (max: 2000)
-fermenter.yield.sapling=50
+fermenter.yield.sapling=100
 # modifies the amount of biomass a piece of cactus will yield in a fermenter. (max: 400)
-fermenter.yield.cactus=10
+fermenter.yield.cactus=20
 # modifies the amount of biomass a piece of wheat will yield in a fermenter. (max: 400)
-fermenter.yield.wheat=10
+fermenter.yield.wheat=20
 # modifies the amount of biomass a mushroom will yield in a fermenter. (max: 400)
-fermenter.yield.mushroom=10
+fermenter.yield.mushroom=20
 # modifies the amount of biomass a piece of sugar cane will yield in a fermenter. (max: 400)
-fermenter.yield.cane=10
+fermenter.yield.cane=20
 
 
 #####################
 # FUEL
 #####################
 # modifies the energy provided by ethanol in a Bio Generator.
-fuel.ethanol.generator=0.5
+fuel.ethanol.generator=1.0
 # modifies the energy provided by ethanol in Buildcraft Combustion Engines.
-fuel.ethanol.combustion=0.5
+fuel.ethanol.combustion=1.0
 # modifies the energy provided by Biomass in a Bio Generator.
-fuel.biomass.generator=0.5
+fuel.biomass.generator=1.0
 # modifies the energy provided by Biomass in Biogas Engines.
-fuel.biomass.biogas=0.5
+fuel.biomass.biogas=1.0
 
 
 #####################


### PR DESCRIPTION
On Forestry HARD mode, the MJ energy costs of running the Still, Squeezer, and Fermenter are 4x and the amount of biomass produced by the Fermenter is cut in half, which means producing Ethanol costs roughly 8x as much vs. NORMAL mode.

In this pack, that make Ethanol net energy negative unless you use Mahoe (High sappiness) saplings and are producing the best fruit, and are using exactly the GT Basic Distillery, GT Fluid Extractor, and large Railcraft boilers. Charcoal, however, is very much net energy positive. The end result is Ethanol is nerfed severely compared to other renewable energy sources like charcoal, oil/fuel from bees, oilberries, MOX reactors, etc.,.

To compensate for this, I have tested and am using the config changes above. A simple doubling of the Fermenter biomass output is enough for Ethanol to start to compete with charcoal again. It's still not nearly as efficient as charcoal, but at least it's not as punishing as before.

I could have gone further, but I like to err on the side of smaller changes for fear of upsetting balance.
