### PR TITLE
Update PneumaticCraft.cfg

### DIFF
--- a/config/PneumaticCraft.cfg
+++ b/config/PneumaticCraft.cfg
@@ -75,28 +75,28 @@ helmet_options {
 
 machine_properties {
     # Changing this value will alter the pressurized air production of the Electric Compressor. The input, EU, will stay the same.
-    I:"Electric Compressor (IC2 --> PneumaticCraft) efficiency"=40
+    I:"Electric Compressor (IC2 --> PneumaticCraft) efficiency"=100
 
     # Changing this value will alter the pressurized air production of the Flux Compressor. The input, RF, will stay the same.
-    I:"Flux Compressor (RF --> PneumaticCraft) efficiency"=70
+    I:"Flux Compressor (RF --> PneumaticCraft) efficiency"=100
 
     # The max height of an elevator per stacked Elevator Base. [range: 1 ~ 256, default: 4]
     I:"Height per Elevator Base"=4
 
     # Changing this value will alter the pressurized air production of the Kinetic Compressor. The input, MJ, will stay the same.
-    I:"Kinetic Compressor (Buildcraft --> PneumaticCraft) efficiency"=40
+    I:"Kinetic Compressor (Buildcraft --> PneumaticCraft) efficiency"=100
 
     # Changing this value will alter the pressurized air usage of the Pneumatic Dynamo. The output, RF, will stay the same.
-    I:"Pneumatic Dynamo (PneumaticCraft --> RF) efficiency"=70
+    I:"Pneumatic Dynamo (PneumaticCraft --> RF) efficiency"=100
 
     # Changing this value will alter the pressurized air usage of the Pneumatic Engine. The output, MJ, will stay the same.
-    I:"Pneumatic Engine (PneumaticCraft --> Buildcraft) efficiency"=40
+    I:"Pneumatic Engine (PneumaticCraft --> Buildcraft) efficiency"=100
 
     # Changing this value will alter the pressurized air usage of the Pneumatic Generator. The output, EU, will stay the same.
-    I:"Pneumatic Generator (PneumaticCraft --> IC2) efficiency"=70
+    I:"Pneumatic Generator (PneumaticCraft --> IC2) efficiency"=100
 
     # Changing this value will alter the hydraulic bar production of the Pneumatic Pump. The input, air, will stay the same.
-    I:"Pneumatic Pump (PneumaticCraft --> Hydraulicraft) efficiency"=40
+    I:"Pneumatic Pump (PneumaticCraft --> Hydraulicraft) efficiency"=100
 }
 
 


### PR DESCRIPTION
Set all energy-conversion machines to use standard conversion rates at full efficiency.  This is due to the Heat mechanic that has been added to the machines, making them virtually impossible to use efficiently with moderate amounts of energy throughput. 

Note: Galacticraft energy conversion machines will need to be adjusted to run at lower efficiency both for balance and exploitive reasons.