### PR TITLE
Update power-GC3.conf

### DIFF
--- a/config/Galacticraft/power-GC3.conf
+++ b/config/Galacticraft/power-GC3.conf
@@ -4,7 +4,7 @@ compatibility {
     D:"BuildCraft Conversion Ratio"=16.0
     B:"Disable old Buildcraft API (MJ) interfacing completely?"=false
     D:"IndustrialCraft Conversion Ratio"=6.557376861572266
-    I:"Loss factor when converting energy as a percentage (100 = no loss, 90 = 10% loss ...)"=100
+    I:"Loss factor when converting energy as a percentage (100 = no loss, 90 = 10% loss ...)"=75
     D:"Mekanism Conversion Ratio"=0.6557376980781555
     D:"RF Conversion Ratio"=1.600000023841858
 }


### PR DESCRIPTION
Galacticraft energy conversion machines will run less efficiently than in PneumaticCraft
- prevents power exploits
- balance: PneumaticCraft machines require vastly more infrastructure to run efficiently (Heat mechanic added recently)