### PR TITLE
moved bcquarry -> enderquarry recipe into qed

### DIFF
--- a/scripts/extrautilities.zs
+++ b/scripts/extrautilities.zs
@@ -99,7 +99,7 @@ recipes.addShaped(filingCabinet, [
     [plateSteel, chestIron, plateSteel],
     [plateSteel, chestIron, plateSteel],
     [plateSteel, chestIron, plateSteel]]);
-recipes.addShaped(enderQuarry, [
+mods.extraUtils.QED.addShapedRecipe(enderQuarry, [
 	[enderPump, BCQuarry, enderCore]]);
 recipes.remove(pipeTransfer);
 recipes.addShaped(pipeTransfer * 2, [


### PR DESCRIPTION
I moved the bcquarry -> enderquarry into the qed because its confusion people that its shown on the first page of NEI.
There is someone asking about this on the forum every week so it would be better if both recipes are on the same page.