### PR TITLE
fixed block recipes

### DIFF
--- a/scripts/bluepower.zs
+++ b/scripts/bluepower.zs
@@ -86,7 +86,7 @@ recipes.removeShapeless(itemGemSapphire);
 recipes.removeShapeless(dustSapphire);
 
 recipes.removeShapeless(gemRuby);
-recipes.removeShapeless(dustRuby;
+recipes.removeShapeless(dustRuby);
 
 recipes.remove(sawAmethyst);
 recipes.addShaped(sawAmethyst, [

--- a/scripts/bluepower.zs
+++ b/scripts/bluepower.zs
@@ -25,6 +25,8 @@ var ingotRedAlloy = <ore:ingotRedAlloy>;
 var ingotSilver = <gregtech:gt.metaitem.01:11054>;
 var ingotZinc = <gregtech:gt.metaitem.01:11036>;
 var itemGemSapphire = <gregtech:gt.metaitem.01:8503>;
+var dustSapphire = <ore:dustSapphire>;
+var blockSapphire = <ore:blockSapphire>;
 var obsidian = <minecraft:obsidian>;
 var plateIron = <ore:plateIron>;
 var sand = <minecraft:sand>;
@@ -41,6 +43,8 @@ var wireRedAlloy = <bluepower:part.wire.redalloy>;
 var stickWood = <ore:stickWood>;
 var rodStone = <ore:rodStone>;
 var gemAmethyst = <ore:gemAmethyst>;
+var dustAmethyst = <ore:dustAmethyst>;
+var blockAmethyst = <ore:blockAmethyst>;
 var sawAmethyst = <bluepower:amethyst_saw>;
 var axeAmethyst = <bluepower:amethyst_axe>;
 var swordAmethyst = <bluepower:amethyst_sword>;
@@ -50,6 +54,9 @@ var hoeAmethyst = <bluepower:amethyst_hoe>;
 var gtIngotRedAlloy = <gregtech:gt.metaitem.01:11308>;
 var dustSilver = <gregtech:gt.metaitem.01:2054>;
 var ingotGold = <minecraft:gold_ingot>;
+var gemRuby = <ore:gemRuby>;
+var dustRuby = <ore:dustRuby>;
+var blockRuby = <ore:blockRuby>;
 
 
 # Item/block Removal
@@ -71,6 +78,16 @@ recipes.remove(hoeAmethyst);
 NEI.hide(hoeAmethyst);
 
 # Recipe tweaks
+
+recipes.removeShapeless(gemAmethyst);
+recipes.removeShapeless(dustAmethyst);
+
+recipes.removeShapeless(itemGemSapphire);
+recipes.removeShapeless(dustSapphire);
+
+recipes.removeShapeless(gemRuby);
+recipes.removeShapeless(dustRuby;
+
 recipes.remove(sawAmethyst);
 recipes.addShaped(sawAmethyst, [
 	[stickWood, rodStone, rodStone],

--- a/scripts/bluepower.zs
+++ b/scripts/bluepower.zs
@@ -1,4 +1,5 @@
 // --- Created by Jason McRay ---
+// --- InfiTech2 script for BluePower ---
 
 import mods.gregtech.AlloySmelter;
 import mods.gregtech.Assembler;

--- a/scripts/hee.zs
+++ b/scripts/hee.zs
@@ -1,19 +1,28 @@
 // -- Created by Jason McRay --
 // -- Created by adamsonich --
+// -- Modified by DarknessShadow --
 
 import mods.ic2.Compressor;
 import mods.ic2.Macerator;
+import mods.gregtech.ArcFurnace;
 
 # Aliases
-var blockEndium = <HardcoreEnderExpansion:endium_block>;
-var ingotEndium = <HardcoreEnderExpansion:endium_ingot>;
-var oreStardust = <HardcoreEnderExpansion:stardust_ore>;
-var oreEndPowder = <HardcoreEnderExpansion:end_powder_ore>;
-var stardust = <HardcoreEnderExpansion:stardust>;
-var endPowder = <HardcoreEnderExpansion:end_powder>;
+var blockEndium     = <HardcoreEnderExpansion:endium_block>;
+var ingotEndium     = <HardcoreEnderExpansion:endium_ingot>;
+var dustEndium      = <gregtech:gt.metaitem.01:2770>;
+var oreStardust     = <HardcoreEnderExpansion:stardust_ore>;
+var oreEndPowder    = <HardcoreEnderExpansion:end_powder_ore>;
+var stardust        = <HardcoreEnderExpansion:stardust>;
+var endPowder       = <HardcoreEnderExpansion:end_powder>;
+var oxygen          = <liquid:oxygen>;
 
 # GT/IC2 Integration
 recipes.remove(blockEndium);
+recipes.remove(ingotEndium);
 Compressor.addRecipe(blockEndium, ingotEndium * 9);
+Macerator.addRecipe(dustEndium * 9, blockEndium);
 Macerator.addRecipe(stardust * 4, oreStardust);
 Macerator.addRecipe(endPowder * 4, oreEndPowder);
+
+//ArcFurnace.addRecipe([output1, output2, output3, output4], input, liquid, [chance1, chance2, chance3, chance4], durationTicks, euPerTick);
+ArcFurnace.addRecipe([ingotEndium * 9], blockEndium, oxygen * 1000, [10000], 2000, 32);

--- a/scripts/hee.zs
+++ b/scripts/hee.zs
@@ -1,6 +1,7 @@
 // -- Created by Jason McRay --
 // -- Created by adamsonich --
 // -- Modified by DarknessShadow --
+// -- InfiTech2 script for Hardcore Ender Expansion --
 
 import mods.ic2.Compressor;
 import mods.ic2.Macerator;

--- a/scripts/opencomputers.zs
+++ b/scripts/opencomputers.zs
@@ -1,0 +1,16 @@
+// --- Created by DarknessShadow ---
+
+import mods.ic2.Compressor;
+import mods.ic2.Macerator;
+
+# Aliases
+
+var chamelium       = <OpenComputers:item:96>;
+var chameliumBlock  = <OpenComputers:chameliumBlock>;
+
+# Recipe Tweaks
+
+recipes.removeShaped(chameliumBlock);
+recipes.removeShapeless(chamelium);
+Compressor.addRecipe(chameliumBlock, chamelium * 9);
+Macerator.addRecipe( chamelium * 9, chameliumBlock);

--- a/scripts/opencomputers.zs
+++ b/scripts/opencomputers.zs
@@ -1,4 +1,5 @@
 // --- Created by DarknessShadow ---
+// --- InfiTech2 script for OpenComputers ---
 
 import mods.ic2.Compressor;
 import mods.ic2.Macerator;

--- a/scripts/redstonearsenal.zs
+++ b/scripts/redstonearsenal.zs
@@ -1,4 +1,5 @@
 // --- Created by DarknessShadow ---
+// --- InfiTech2 script for Redstone Arsenal ---
 
 # Aliases
 

--- a/scripts/redstonearsenal.zs
+++ b/scripts/redstonearsenal.zs
@@ -1,0 +1,10 @@
+// --- Created by DarknessShadow ---
+
+# Aliases
+
+var gemCrystalFlux  = <ore:gemCrystalFlux>;
+var blockCrystalFlux  = <ore:blockCrystalFlux>;
+
+# Recipe Tweaks
+
+recipes.removeShapeless(gemCrystalFlux, [blockCrystalFlux]);

--- a/scripts/thaumcraft.zs
+++ b/scripts/thaumcraft.zs
@@ -1,13 +1,35 @@
 // --- Created by Jason McRay --- 
+// --- Modified by DarknessShadow ---
 
 import mods.thaumcraft.Arcane;
+import mods.ic2.Compressor;
+import mods.gregtech.ArcFurnace;
+import mods.ic2.Macerator;
+import mods.gregtech.ForgeHammer;
 
 # Aliases
-var hungryHandMirror = <Automagy:autoHandMirror>;
-var nuggetThaumium = <ore:nuggetThaumium>;
-var finicalMaw = <Automagy:blockFinicalMaw>;
-var salisMundus = <Thaumcraft:ItemResource:14>;
-var magicHandMirror = <Thaumcraft:HandMirror>;
+var hungryHandMirror        = <Automagy:autoHandMirror>;
+var nuggetThaumium          = <ore:nuggetThaumium>;
+var finicalMaw              = <Automagy:blockFinicalMaw>;
+var salisMundus             = <Thaumcraft:ItemResource:14>;
+var magicHandMirror         = <Thaumcraft:HandMirror>;
+var blockThaumium           = <Thaumcraft:blockCosmeticSolid:4>;
+var ingotThaumium           = <Thaumcraft:ItemResource:2>;
+var dustThaumium            = <gregtech:gt.metaitem.01:2330>;
+var crateThaumium           = <ore:crateGtIngotThaumium>;
+var crateAmber              = <ore:crateGtGemAmber>;
+var craftingToolCrowbar     = <ore:craftingToolCrowbar>;
+var craftingHHammer         = <ore:craftingToolHardHammer>;
+var flawlessAmber           = <ore:gemFlawlessAmber>;
+var oxygen                  = <liquid:oxygen>;
+var magicTallow             = <Thaumcraft:ItemResource:4>;
+var blockTallow             = <Thaumcraft:blockCosmeticSolid:5>;
+var rottenflesh             = <minecraft:rotten_flesh>;
+var blockofFlesh            = <Thaumcraft:blockTaint:2>;
+var blockAmber              = <Thaumcraft:blockCosmeticOpaque>;
+var brickAmber              = <Thaumcraft:blockCosmeticOpaque:1>;
+var Amber 			    = <Thaumcraft:ItemResource:6>;
+var dustAmber	          = <gregtech:gt.metaitem.01:2514>;
 
 # Recipe Fixes
 Arcane.removeRecipe(hungryHandMirror);
@@ -15,4 +37,47 @@ Arcane.addShaped("AUTOHANDMIRROR", hungryHandMirror, "ordo 54, aer 25, perditio 
     [[null, finicalMaw, null],
     [nuggetThaumium, salisMundus, nuggetThaumium],
     [null, magicHandMirror, null]]);
-    
+
+# Recipe Tweaks
+recipes.removeShaped(blockThaumium);
+recipes.remove(ingotThaumium);
+recipes.addShaped(ingotThaumium, [
+    [nuggetThaumium, nuggetThaumium, nuggetThaumium],
+    [nuggetThaumium, nuggetThaumium, nuggetThaumium],
+    [nuggetThaumium, nuggetThaumium, nuggetThaumium]]);
+recipes.addShaped(ingotThaumium * 16, [
+    [crateThaumium, craftingToolCrowbar, null],
+    [null, null, null],
+    [null, null, null]]);
+Compressor.addRecipe(blockThaumium, ingotThaumium * 9);
+Macerator.addRecipe(dustThaumium * 9, blockThaumium);
+ArcFurnace.addRecipe([ingotThaumium * 9], blockThaumium, oxygen * 1000, [10000], 1000, 32);
+
+recipes.remove(blockTallow);
+recipes.remove(magicTallow);
+Compressor.addRecipe(blockTallow, magicTallow * 9);
+Macerator.addRecipe(magicTallow * 9, blockTallow);
+
+recipes.remove(blockofFlesh);
+Compressor.addRecipe(blockofFlesh, rottenflesh * 9);
+Macerator.addRecipe(rottenflesh * 9, blockofFlesh);
+
+recipes.remove(blockAmber);
+recipes.remove(Amber);
+recipes.addShaped( Amber * 16, [
+    [crateAmber, craftingToolCrowbar, null],
+    [null, null, null],
+    [null, null, null]]);
+recipes.addShaped( Amber * 2, [
+    [craftingHHammer, null, null],
+    [flawlessAmber, null, null],
+    [null, null, null]]);
+Compressor.addRecipe(blockAmber, Amber * 4);
+Macerator.addRecipe(dustAmber * 4, blockAmber);
+Macerator.addRecipe(dustAmber * 4, brickAmber);
+ForgeHammer.addRecipe(Amber * 4, blockAmber, 20, 16);
+ForgeHammer.addRecipe(Amber * 4, brickAmber, 20, 16);
+
+
+//ForgeHammer.addRecipe(output1, input, durationTicks, euPerTick);
+//ArcFurnace.addRecipe([output1, output2, output3, output4], input, liquid, [chance1, chance2, chance3, chance4], durationTicks, euPerTick);

--- a/scripts/thaumcraft.zs
+++ b/scripts/thaumcraft.zs
@@ -1,5 +1,6 @@
 // --- Created by Jason McRay --- 
 // --- Modified by DarknessShadow ---
+// --- InfiTech2 script for Thaumcraft ---
 
 import mods.thaumcraft.Arcane;
 import mods.ic2.Compressor;

--- a/scripts/thaumictinkerer.zs
+++ b/scripts/thaumictinkerer.zs
@@ -1,0 +1,11 @@
+// --- Created by DarknessShadow ---
+
+import mods.ic2.Compressor;
+
+# Aliases
+var smokeyquartz        = <ThaumicTinkerer:darkQuartzItem>;
+var blocksmokeyquartz   = <ThaumicTinkerer:darkQuartz>;
+
+# Recipe Tweaks
+recipes.remove(blocksmokeyquartz);
+Compressor.addRecipe(blocksmokeyquartz, smokeyquartz * 4);

--- a/scripts/thaumictinkerer.zs
+++ b/scripts/thaumictinkerer.zs
@@ -1,4 +1,5 @@
 // --- Created by DarknessShadow ---
+// --- InfiTech2 script for Thaumic Tinkerer ---
 
 import mods.ic2.Compressor;
 

--- a/scripts/vanilla.zs
+++ b/scripts/vanilla.zs
@@ -21,6 +21,10 @@ var slabWood = <ore:slabWood>;
 var teleporter = <IC2:blockMachine2>;
 var slabOak = <minecraft:wooden_slab>;
 var plankOak = <minecraft:planks>;
+var lapis	= <ore:gemLapis>;
+var dustLapis	= <ore:dustLapis>;
+var coal	= <ore:gemCoal>;
+var dustCoal	= <ore:dustCoal>;
 
 # OreDictionary
 potionHealing.add(<minecraft:potion:8197>);
@@ -48,6 +52,10 @@ recipes.addShaped(chestWood * 4, [
 recipes.remove(slabOak);
 recipes.addShaped(slabOak * 2, [
 	[saw, plankOak]]);
+recipes.removeShapeless(lapis);
+recipes.removeShapeless(dustLapis);
+recipes.removeShapeless(coal);
+recipes.removeShapeless(dustCoal);
 	
 # Recipe Fixes
 recipes.remove(sensorDaylight);


### PR DESCRIPTION
Some blocks didn't have the compressor recipes and some could be turned back without machines.
I fixed it for:
Coal
Lapis
Chamelium
Flux Crystal
Amethyst
Sapphire
Ruby

edit: now also fixed for
Endium
Smokey Quartz
Thaumium
Magic Tallow
Rotten Flesh
Amber