### PR TITLE
Uranium/Plutonium Centrifuge buff

### DIFF
--- a/config/GregTech/Recipes.cfg
+++ b/config/GregTech/Recipes.cfg
@@ -16897,7 +16897,8 @@ centrifuge {
     I:dustPitchblende_2820=2820
     I:dustPlatinumGroupSludge_600=600
     I:dustPlatinumGroupSludge_900=900
-    I:dustPlutonium_1600=1600
+    I:dustPlutonium_1599=1599
+    I:dustPlutonium_1600=0
     I:dustPowellite_792=792
     I:dustPumice_392=392
     I:dustPureAdamantium_784=784
@@ -17150,7 +17151,8 @@ centrifuge {
     I:dustTungstenCarbide_776=776
     I:dustTungstenSteel_952=952
     I:dustUraninite_1080=1080
-    I:dustUranium_800=800
+    I:dustUranium_799=799
+    I:dustUranium_800=0
     I:dustVanadiumGallium_880=880
     I:dustVanadiumMagnetite_336=336
     I:dustVanadiumSteel_1980=1980

--- a/scripts/gt_ic2.zs
+++ b/scripts/gt_ic2.zs
@@ -6,6 +6,7 @@ import mods.gregtech.ArcFurnace;
 import mods.gregtech.PlasmaArcFurnace;
 import mods.ic2.SemiFluidGenerator;
 import mods.gregtech.Printer;
+import mods.gregtech.Centrifuge;
 import mods.gregtech.CuttingSaw;
 import mods.nei.NEI;
 import minetweaker.game.IGame;
@@ -41,8 +42,14 @@ var cropHarvester           = <IC2:blockMachine3:7>;
 var diamondDrill            = <IC2:itemToolDDrill:*>;
 var dustGlowstone           = <ore:dustGlowstone>;
 var dustLead                = <ore:dustLead>;
+var dustPlutonium244        = <gregtech:gt.metaitem.01:2100>;
 var dustSulfur              = <ore:dustSulfur>;
 var dustThorium             = <gregtech:gt.metaitem.01:2096>;
+var dustTinyPlutonium241    = <gregtech:gt.metaitem.01:101>;
+var dustTinyPlutonium244    = <gregtech:gt.metaitem.01:100>;
+var dustTinyUranium235      = <gregtech:gt.metaitem.01:97>;
+var dustTinyUranium238      = <gregtech:gt.metaitem.01:98>;
+var dustUranium238          = <gregtech:gt.metaitem.01:2098>;
 var dustWheat               = <ore:dustWheat>;
 var electricJetpack         = <IC2:itemArmorJetpackElectric>;
 var electricWrench          = <IC2:itemToolWrenchElectric:*>;
@@ -571,3 +578,8 @@ for log in logWood {
 
 Compressor.addRecipe(plantball, sapling * 4);
 Compressor.addRecipe(plantball, sugarcane * 8);
+
+# Uranium Centrifuge Buff
+//OutputArray, InputFluid, InputStack, InputCell, OutputFluid, OutputArrayChances, Time in Ticks, EnergyUsage
+Centrifuge.addRecipe([dustTinyUranium235, dustTinyPlutonium244], null, dustUranium238, null, null, [8000, 800], 799, 320);
+Centrifuge.addRecipe([dustTinyPlutonium241, dustTinyUranium238 * 2], null, dustPlutonium244, null, null, [8000, 6000], 1599, 320);


### PR DESCRIPTION
Quadruples the output of centrifuging Uranium-238 and Plutonium-244, the maths is as follows.

Base Rates, all numbers are averages, Pu-244 U-238 yield ignored for simplicity and irrelevance.

For 1 Pu-241 you need to centrifuge 45 Pu-244 on average, providing 1.5 U-238 as well.

For acquiring Pu-244 there are 3 methods.

Centrifuge U-238 dust.

15 U-238 dust gives 1/3 U-235 dust and 1/30 Pu-244 dust.
45 U-238 dust gives 1 U-235 dust and 0.1 Pu-244 dust.

However primarily they should be combined with the reactor for yield, both Uranium and MOX are options.

1 Uranium Fuel Rod costs 6 U-238 and 1/3 U-235, or 21 U-238 combined. It yields 1/9 Pu-244 and 4 U-238, changing net yield to 1/9 Pu-244 for 17 U-238. Accounting for the extra from centrifuging to acquire the U-235 changes it to 13/90, an extra 30% Pu-244 yield.

1 MOX Fuel Rod costs 6 U-238 and 3 Pu-244, and yields 3+1/9 Pu-244 for a net yield of 1/9 Pu-244 for 6 U-238, no centrifuging is required but the initial Pu-244 must be obtained before hand.

So via pure centrifuging approximately 20.5k U-238 must be centrifuged, this holds the advantage of being far faster than the other options but massively energy and resource consuming compared to them. You will produce several stacks of U-235 for reactor setups for quite a long time as a side effect.

For Uranium Fuel Rods you produce 13/90 U-235 per 17 U-238, leading to a total cost for 45 Pu-244 as about 5.3k U-238, along with needing to run about 311 fuel rods through reactors.

For MOX Fuel Rods it's trickier due to startup cost, at 54 U-238 per Pu-244 it far beats out the 117 of Uranium Fuel Rods and the 450 of the centrifuge. Ignoring startup cost a relatively small 2.4k U-238, and needing to run 405 MOX Fuel Rods through reactors, as they take half the time of a Uranium Fuel Rod this will be significantly faster despite the increased cost.

To account for a startup cost you need 3 Pu-244 to create a MOX Fuel Rod to get started, about 21 Uranium Fuel Rods worth. Reusing this plutonium at the end further complicates the figures but it's only a 7% difference.

Processing U-238 or Uraninite ore can lower the costs by allowing for an alternative source of U-235 for Uranium Fuel Rod based systems, or allowing faster entry into MOX based systems. For U-238 Ore this is an extra 19/90 per purified ore, saving 38/90 U-235 generation given normal ore processing, about a single fuel rod worth of plutonium after accounting for the penalty from not centrifuging, saving approximately 15 U-238 per ore processed. Uraninite ore only gives 0.1 U-235 per purified ore, so approximately half the benefit of U-238 at around 7 U-238 saved per ore processed for U-235 given a uranium fuel rod system.

Quadruple rates, explanations will be much more brief due to the numbers just being different.

11.25 Pu-244 gives 1   Pu-241 and 3/2   U-238
 3.75  U-238 gives 1/3  U-235 and 1/30 Pu-244

Via Centrifuging

1 Pu-241 requires 11.25 Pu-244 and thus ~1266 U-238, produces 45 U-235 as by-products.

Via Uranium Fuel Rods

1 Uranium Fuel Rod has a net cost of 7.75 U-238, decreasing total for 1 Pu-244 to 70 U-238 over the previous 117 and only ~790 U-238 in total.

Via MOX Fuel Rods

MOX Fuel Rods are just quartered for Pu-241 gain, as they didn't centrifuge U-238 in the first place. Cost remains ahead of Uranium Fuel Rods with 54 vs 70 but much less so, ~610 U-238 for 1 Pu-241.

The benefits of ore processing are lowered, U-238 Ore now only saves nearly 4 U-238 and Uraninite only around 1.5 U-238.