### PR TITLE
Fix paint exploit

### DIFF
--- a/config/buildcraft/objects.cfg
+++ b/config/buildcraft/objects.cfg
@@ -44,7 +44,7 @@ items {
     B:list=true
     B:mapLocation=true
     B:package=true
-    B:paintbrush=true
+    B:paintbrush=false
     B:pipeFacade=true
     B:pipeGate=true
     B:pipeLens=true

--- a/scripts/gt_ic2.zs
+++ b/scripts/gt_ic2.zs
@@ -74,6 +74,7 @@ var ic2MassFab              = <IC2:blockMachine:14>;
 var ic2MetalFormer          = <IC2:blockMachine2:4>;
 var ic2OreWashingPlant      = <IC2:blockMachine2:5>;
 var ic2PatternStorage       = <IC2:blockMachine2:6>;
+var ic2Painter              = <IC2:itemToolPainter>;
 var ic2Recycler             = <IC2:blockMachine:11>;
 var ic2Replicator           = <IC2:blockMachine2:8>;
 var ic2Scanner              = <IC2:blockMachine2:7>;
@@ -511,6 +512,11 @@ recipes.addShaped(rotorCarbon, [
     [screwIridium, rotorBladeCarbon, HHammer],
     [rotorBladeCarbon, rotorSteel, rotorBladeCarbon],
     [Wrench, rotorBladeCarbon, screwIridium]]);
+recipes.remove(ic2Painter);
+recipes.addShaped(ic2Painter,
+[[<ore:blockWool>, <ore:blockWool>, <ore:blockWool>],
+[null, <ore:stickTinAlloy>, <ore:craftingToolHardHammer>],
+[null, <ore:stickTinAlloy>, <ore:plateRubber>]]);
     
 # Specials
 SemiFluidGenerator.addFluid(<liquid:creosote> * 53, 8);

--- a/scripts/openblocks.zs
+++ b/scripts/openblocks.zs
@@ -67,4 +67,4 @@ recipes.remove(paintbrush);
 recipes.addShaped(paintbrush,
   [[<ore:blockWool>, null, null],
   [<ore:craftingToolFile>, <Forestry:oakStick>, null],
-  [null, null, <Forestry:oakStick>]]);
+  [null, null, <ore:woodStickSealed>]]);

--- a/scripts/openblocks.zs
+++ b/scripts/openblocks.zs
@@ -18,6 +18,7 @@ var craneControl      = <OpenBlocks:craneControl>;
 var craneMagnet       = <OpenBlocks:generic:3>;
 var craneEngine       = <OpenBlocks:generic:2>;
 var luggage           = <OpenBlocks:luggage>;
+var paintbrush        = <OpenBlocks:paintBrush>;
 
 # Recipe Tweaks
 recipes.remove(vacuumHopper);
@@ -61,3 +62,9 @@ craneEngine.addTooltip(format.red(format.bold("This item is DISABLED!")));
 
 recipes.remove(luggage);
 luggage.addTooltip(format.red(format.bold("This item is DISABLED!")));
+
+recipes.remove(paintbrush);
+recipes.addShaped(paintbrush,
+  [[<ore:blockWool>, null, null],
+  [<ore:craftingToolFile>, <Forestry:oakStick>, null],
+  [null, null, <Forestry:oakStick>]]);


### PR DESCRIPTION
I'm not sure how many people have realized this yet, but you can easily circumvent the annoying need for black carpet for tin cable by using one of the three paint brushes. The OpenBlocks paintbrush has a  questionable 25 uses, the IC2 painter has a predictable 32 uses, and the BC paintbrush has an astounding 64 uses per dye. The BC paintbrush was immediately disabled. Since the OB paintbrush is the only one that can accept custom dye colors, I just gregged the recipe for it and the IC2 painter. This means you now have to at least have LV tech to make them, meaning you have to make at least some of the black carpet the hard way. All three of the brushes could color GT (and IC2) cables, BC pipes, RC tank walls, and AE2 cables, so there was no conflict there.