### PR TITLE
Disable overlapping MB resource bees

### DIFF
--- a/config/forestry/apiculture.cfg
+++ b/config/forestry/apiculture.cfg
@@ -184,7 +184,18 @@ beekeeping {
 species {
     # Add species to blacklist identified by their uid, one per line. [default: ]
     S:blacklist <
-    magicbees.speciesOsmium
+        magicbees.speciesOsmium
+        magicbees.speciesIron
+        magicbees.speciesGold
+        magicbees.speciesCopper
+        magicbees.speciesTin
+        magicbees.speciesSilver
+        magicbees.speciesLead
+        magicbees.speciesCobalt
+        magicbees.speciesDiamond
+        magicbees.speciesEmerald
+        magicbees.speciesCertus
+        magicbees.speciesFluix
      >
 }
 

--- a/config/forestry/apiculture.cfg
+++ b/config/forestry/apiculture.cfg
@@ -196,6 +196,7 @@ species {
         magicbees.speciesEmerald
         magicbees.speciesCertus
         magicbees.speciesFluix
+        magicbees.speciesSilicon
      >
 }
 

--- a/config/gendustry/Bees.en_US.lang
+++ b/config/gendustry/Bees.en_US.lang
@@ -21,6 +21,7 @@ gendustry.bees.species.Sapphire=Sapphire
 gendustry.bees.species.Diamond=Diamond
 gendustry.bees.species.Olivine=Olivine
 gendustry.bees.species.Emerald=Emerald
+gendustry.bees.species.Silicon=Silicon
 gendustry.bees.species.Copper=Copper
 gendustry.bees.species.Tin=Tin
 gendustry.bees.species.Lead=Lead

--- a/config/gendustry/bees.cfg
+++ b/config/gendustry/bees.cfg
@@ -58,7 +58,7 @@ cfg Bees {
         Authority = InfinityTeam
         Branch = "beesOrganic"
         Products = DropsList( 
-            30% I:Forestry:beeCombs@0 // Mossy Comb
+            30% I:Forestry:beeCombs@15 // Mossy Comb
             15% S:minecraft:"slime_ball"
             )
         Specialty = DropsList()
@@ -177,7 +177,7 @@ cfg Bees {
         Authority = InfinityTeam
         Branch = "beesThaumic"
         Products = DropsList( 
-            30% I:Forestry:beeCombs@6 // Stringy Comb
+            30% I:Forestry:beeCombs@3 // Stringy Comb
             15% S:gendustry:"HoneyComb.thaumiumdust"
             )
         Specialty = DropsList()
@@ -224,7 +224,7 @@ cfg Bees {
         Authority = InfinityTeam
         Branch = "beesThaumic"
         Products = DropsList( 
-            30% I:Forestry:beeCombs@6 // Stringy Comb
+            30% I:Forestry:beeCombs@3 // Stringy Comb
             )
         Specialty = DropsList(
             10% I:Thaumcraft:ItemResource@6 // Amber
@@ -247,7 +247,7 @@ cfg Bees {
         Authority = InfinityTeam
         Branch = "beesThaumic"
         Products = DropsList( 
-            30% I:Forestry:beeCombs@6 // Stringy Comb
+            30% I:Forestry:beeCombs@3 // Stringy Comb
             )
         Specialty = DropsList(
             10% I:Thaumcraft:ItemNugget@5 //quick silver drop
@@ -473,6 +473,31 @@ cfg Bees {
             Base = "forestry.speciesCommon"
             }
         }  
+        
+    cfg Silicon {
+        Dominant = Yes
+        Glowing = No
+        PrimaryColor = 0xADA2A7
+        SecondaryColor = 0x685C6A
+        Secret = No
+        Humidity = Normal
+        Temperature = Normal
+        Nocturnal = Yes
+        Binominal = Silicon
+        Authority = InfinityTeam
+        Branch = "beesGem"
+        Products = DropsList(
+            10% I:Forestry:beeCombs@0 // Honey Comb
+            ) 
+        Specialty = DropsList(
+            16% I:gregtech:"gt.metaitem.01"@1020 // Small Silicon Dust
+            )
+        cfg Traits {
+            Base = "forestry.speciesCommon"
+            Nocturnal = "forestry.boolTrue"
+            Tolerant_Flyer = "forestry.boolTrue"
+            }
+        }
         
       
       //<~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ beesMetalic Branch ~~~~~~~~~~~~~~~~~~~~~>
@@ -1249,7 +1274,8 @@ mutation: 1% "gendustry.bee.Plutonium" + "gendustry.bee.Iridium" => "gendustry.b
 mutation: 1% "gendustry.bee.Naquadah" + "gendustry.bee.ThaumiumShard" => "gendustry.bee.DOB" Req Biome Sky Req Block B:AdvancedSolarPanel:BlockAdvSolarPanel@2
 
 // Magic Bees Replacement Mutations
-mutation: 17% "magicbees.speciesAESkystone" + "gendustry.bee.Iron" => "magicbees.speciesSilicon"
+mutation: 20% "magicbees.speciesEarthen" + "magicbees.speciesWindy" => "magicbees.speciesAESkystone" Req Block B:OpenBlocks:sky@0
+mutation: 17% "magicbees.speciesAESkystone" + "gendustry.bee.Iron" => "gendustry.bee.Silicon"
 mutation: 5% "magicbees.speciesTCFlux" + "gendustry.bee.ThaumiumDust" => "magicbees.speciesTCVoid" Req Biome Eerie
 mutation: 12% "forestry.speciesRural" + "gendustry.bee.Copper" => "magicbees.speciesApatite" Req Block B:Forestry:resourceStorage@0
 }

--- a/config/gendustry/bees.cfg
+++ b/config/gendustry/bees.cfg
@@ -1247,5 +1247,10 @@ mutation: 2% "forestry.speciesAvenging" + "gendustry.bee.Lead" => "gendustry.bee
 mutation: 1% "gendustry.bee.Uranium" + "gendustry.bee.Emerald" => "gendustry.bee.Plutonium"
 mutation: 1% "gendustry.bee.Plutonium" + "gendustry.bee.Iridium" => "gendustry.bee.Naquadah"
 mutation: 1% "gendustry.bee.Naquadah" + "gendustry.bee.ThaumiumShard" => "gendustry.bee.DOB" Req Biome Sky Req Block B:AdvancedSolarPanel:BlockAdvSolarPanel@2
+
+// Magic Bees Replacement Mutations
+mutation: 17% "magicbees.speciesAESkystone" + "gendustry.bee.Iron" => "magicbees.speciesSilicon"
+mutation: 5% "magicbees.speciesTCFlux" + "gendustry.bee.ThaumiumDust" => "magicbees.speciesTCVoid" Req Biome Eerie
+mutation: 12% "forestry.speciesRural" + "gendustry.bee.Copper" => "magicbees.speciesApatite" Req Block B:Forestry:resourceStorage@0
 }
 //End


### PR DESCRIPTION
Several bees exist from magical bees that directly give nuggets and for which a custom variant already exists, this removes them. It also removes cobalt for which we do not have an equivalent bee, but nickel combs already work to purifying cobaltite.