### PR TITLE
Redo SAG Mill recipes

### DIFF
--- a/config/enderio/SAGMillRecipes_User.xml
+++ b/config/enderio/SAGMillRecipes_User.xml
@@ -138,6 +138,11 @@ found in the core file.
     <recipe name="LapisLazuliOre" />
     <recipe name="Quartz Ore" />
   </recipeGroup>
+  
+  <recipeGroup name="Applied Energistics 2">
+    <recipe name="ChargedCertusQuartzOre" />
+    <recipe name="CertusQuartzOre" />
+  </recipeGroup>
 
   <recipeGroup name="Common Ores/Ingots/Blocks" enabled="false" />
   

--- a/config/enderio/SAGMillRecipes_User.xml
+++ b/config/enderio/SAGMillRecipes_User.xml
@@ -4951,4 +4951,19 @@ found in the core file.
     </recipe>
   </recipeGroup>
 
+  <grindingBalls>
+    <grindingBall id="Flint" remove="true" />
+    <grindingBall id="DarkSteelBall" remove="true" />
+
+    <grindingBall id="IronRound" grindingMultiplier="1.2" chanceMultiplier="1.25" powerMultiplier="0.85" durationRF="6000" >
+      <itemStack oreDictionary="roundIron" />
+    </grindingBall>
+    <grindingBall id="DarkSteelRound" grindingMultiplier="1.5" chanceMultiplier="2" powerMultiplier="0.7" durationRF="12000" >
+      <itemStack oreDictionary="roundDarkSteel" />
+    </grindingBall>
+    <grindingBall id="TungstenSteelRound" grindingMultiplier="1.5" chanceMultiplier="2" powerMultiplier="0.7" durationRF="60000" >
+      <itemStack oreDictionary="roundTungstenSteel" />
+    </grindingBall>
+  </grindingBalls>
+
 </SAGMillRecipes>

--- a/config/enderio/SAGMillRecipes_User.xml
+++ b/config/enderio/SAGMillRecipes_User.xml
@@ -107,6 +107,9 @@ found in the core file.
     <!-- Removing the ways of obtaining EnderIO Silicon from sand -->
     <recipe name="Silicon" />
     <recipe name="SiliconRedSand" />
+    <recipe name="CoalOre" />
+    <recipe name="IronOre" />
+    <recipe name="GoldOre" />
   </recipeGroup>
   
   <recipeGroup name="Vanilla">
@@ -129,138 +132,4375 @@ found in the core file.
         <itemStack modID="minecraft" itemName="clay_ball" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="RedstoneOre" energyCost="3000">
+    <recipe name="RedstoneOre" />
+    <recipe name="DiamondOre" />
+    <recipe name="EmeraldOre" />
+    <recipe name="LapisLazuliOre" />
+    <recipe name="Quartz Ore" />
+  </recipeGroup>
+
+  <recipeGroup name="Common Ores/Ingots/Blocks" enabled="false" />
+  
+  <recipeGroup name="Biomes O' Plenty" enabled="false" />
+
+  <recipeGroup name="TConstruct" enabled="false" />
+
+  <recipeGroup name="Metallurgy" enabled="false" />
+
+  <recipeGroup name="Railcraft" >
+    <recipe name="Sulfur Ore" />
+    <recipe name="Saltpeter" />
+  </recipeGroup>
+
+  <recipeGroup name="GT Ores">
+    <recipe name="NetherrackTinOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTin" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneTinOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTin" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="TinOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTin" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteTinOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTin" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteTinOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTin" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackRedstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackRedstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRedstone" number="10" />
+        <itemStack oreDictionary="dustCinnabar" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneRedstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneRedstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRedstone" number="10" />
+        <itemStack oreDictionary="dustCinnabar" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedstoneOre" energyCost="32000">
       <input>
         <itemStack oreDictionary="oreRedstone" />
       </input>
       <output>
-        <itemStack modID="minecraft" itemName="redstone" number="8" />
-        <itemStack modID="minecraft" itemName="redstone" number="1" chance="0.2" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.15" />
+        <itemStack oreDictionary="crushedRedstone" number="10" />
+        <itemStack oreDictionary="dustCinnabar" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="DiamondOre" energyCost="3000" >
+    <recipe name="RedgraniteRedstoneOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreDiamond" />
+        <itemStack oreDictionary="oreRedgraniteRedstone" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedDiamond" number="2" />
-        <itemStack oreDictionary="gemChippedDiamond" chance="0.25" />
+        <itemStack oreDictionary="crushedRedstone" number="10" />
+        <itemStack oreDictionary="dustCinnabar" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="EmeraldOre" energyCost="3000" >
+    <recipe name="BlackgraniteRedstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteRedstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRedstone" number="10" />
+        <itemStack oreDictionary="dustCinnabar" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackEmeraldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackEmerald" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedEmerald" number="2" />
+        <itemStack oreDictionary="dustBeryllium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneEmeraldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneEmerald" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedEmerald" number="2" />
+        <itemStack oreDictionary="dustBeryllium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EmeraldOre" energyCost="32000">
       <input>
         <itemStack oreDictionary="oreEmerald" />
       </input>
       <output>
         <itemStack oreDictionary="crushedEmerald" number="2" />
-        <itemStack oreDictionary="gemChippedEmerald" number="1" chance="0.25" />
+        <itemStack oreDictionary="dustBeryllium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="LapisLazuliOre" energyCost="3000" >
+    <recipe name="RedgraniteEmeraldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteEmerald" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedEmerald" number="2" />
+        <itemStack oreDictionary="dustBeryllium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteEmeraldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteEmerald" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedEmerald" number="2" />
+        <itemStack oreDictionary="dustBeryllium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLapisOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLapis" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLapis" number="12" />
+        <itemStack oreDictionary="gemLazurite" chance="0.4" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLapisOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLapis" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLapis" number="12" />
+        <itemStack oreDictionary="gemLazurite" chance="0.4" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="LapisOre" energyCost="32000">
       <input>
         <itemStack oreDictionary="oreLapis" />
       </input>
       <output>
         <itemStack oreDictionary="crushedLapis" number="12" />
-        <itemStack oreDictionary="gemLazurite" number="1" chance="0.2" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.15" />
+        <itemStack oreDictionary="gemLazurite" chance="0.4" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="Quartz Ore" energyCost="7200" >
+    <recipe name="RedgraniteLapisOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreQuartz" />
+        <itemStack oreDictionary="oreRedgraniteLapis" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
-        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="12" />
+        <itemStack oreDictionary="gemLazurite" chance="0.4" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
       </output>
     </recipe>
-  </recipeGroup>
-  
-  <recipeGroup name="Applied Energistics 2" >
-    <recipe name="CertusQuartzOre" energyCost="2400" >
+    <recipe name="BlackgraniteLapisOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreCertusQuartz" />
+        <itemStack oreDictionary="oreBlackgraniteLapis" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
-        <itemStack oreDictionary="dustCertusQuartz" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="12" />
+        <itemStack oreDictionary="gemLazurite" chance="0.4" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
       </output>
     </recipe>
-  </recipeGroup>
-  
-  <recipeGroup name="Biomes O' Plenty" >
-  <recipe name="RubyOre" energyCost="2400" >
+    <recipe name="NetherrackCobaltiteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreRuby" />
+        <itemStack oreDictionary="oreNetherrackCobaltite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedRuby" number="2" />
-        <itemStack oreDictionary="gemChippedRuby" number="1" chance="0.25" />
+        <itemStack oreDictionary="crushedCobaltite" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="PeridotOre" energyCost="2400" >
+    <recipe name="EndstoneCobaltiteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="orePeridot" />
+        <itemStack oreDictionary="oreEndstoneCobaltite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPeridot" number="2" />
-        <itemStack oreDictionary="gemChippedPeridot" number="1" chance="0.25" />
+        <itemStack oreDictionary="crushedCobaltite" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="TopazOre" energyCost="2400" >
+    <recipe name="CobaltiteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreTopaz" />
+        <itemStack oreDictionary="oreCobaltite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedTopaz" number="2" />
-        <itemStack oreDictionary="gemChippedTopaz" number="1" chance="0.25" />
+        <itemStack oreDictionary="crushedCobaltite" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="TanzaniteOre" energyCost="2400" >
+    <recipe name="RedgraniteCobaltiteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreTanzanite" />
+        <itemStack oreDictionary="oreRedgraniteCobaltite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedTanzanite" number="2" />
-        <itemStack oreDictionary="gemChippedTanzanite" number="1" chance="0.25" />
+        <itemStack oreDictionary="crushedCobaltite" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="MalachiteOre" energyCost="2400" >
+    <recipe name="BlackgraniteCobaltiteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreMalachite" />
+        <itemStack oreDictionary="oreBlackgraniteCobaltite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedMalachite" number="2" />
-        <itemStack oreDictionary="gemChippedMalachite" number="1" chance="0.25" />
+        <itemStack oreDictionary="crushedCobaltite" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="SapphireOre" energyCost="2400" >
+    <recipe name="NetherrackSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSapphire" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSapphire" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SapphireOre" energyCost="32000">
       <input>
         <itemStack oreDictionary="oreSapphire" />
       </input>
       <output>
         <itemStack oreDictionary="crushedSapphire" number="2" />
-        <itemStack oreDictionary="gemChippedSapphire" number="1" chance="0.25" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="AmberOre" energyCost="2400" >
+    <recipe name="RedgraniteSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSapphire" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSapphire" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMagnetite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMagnetite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="MagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMagnetite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMagnetite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMagnetite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCopperOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCopper" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCopperOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCopper" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="CopperOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCopper" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCopperOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCopper" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCopperOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCopper" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCooperiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCooperite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCooperite" number="2" />
+        <itemStack oreDictionary="dustPalladium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCooperiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCooperite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCooperite" number="2" />
+        <itemStack oreDictionary="dustPalladium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="CooperiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCooperite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCooperite" number="2" />
+        <itemStack oreDictionary="dustPalladium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCooperiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCooperite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCooperite" number="2" />
+        <itemStack oreDictionary="dustPalladium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCooperiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCooperite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCooperite" number="2" />
+        <itemStack oreDictionary="dustPalladium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSalt" number="4" />
+        <itemStack oreDictionary="dustRockSalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSalt" number="4" />
+        <itemStack oreDictionary="dustRockSalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSalt" number="4" />
+        <itemStack oreDictionary="dustRockSalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSalt" number="4" />
+        <itemStack oreDictionary="dustRockSalt" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSalt" number="4" />
+        <itemStack oreDictionary="dustRockSalt" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackOlivineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackOlivine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedOlivine" number="2" />
+        <itemStack oreDictionary="dustPyrope" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneOlivineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneOlivine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedOlivine" number="2" />
+        <itemStack oreDictionary="dustPyrope" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="OlivineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreOlivine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedOlivine" number="2" />
+        <itemStack oreDictionary="dustPyrope" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteOlivineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteOlivine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedOlivine" number="2" />
+        <itemStack oreDictionary="dustPyrope" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteOlivineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteOlivine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedOlivine" number="2" />
+        <itemStack oreDictionary="dustPyrope" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackTetrahedriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackTetrahedrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTetrahedrite" number="2" />
+        <itemStack oreDictionary="dustAntimony" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneTetrahedriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneTetrahedrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTetrahedrite" number="2" />
+        <itemStack oreDictionary="dustAntimony" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="TetrahedriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreTetrahedrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTetrahedrite" number="2" />
+        <itemStack oreDictionary="dustAntimony" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteTetrahedriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteTetrahedrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTetrahedrite" number="2" />
+        <itemStack oreDictionary="dustAntimony" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteTetrahedriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteTetrahedrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTetrahedrite" number="2" />
+        <itemStack oreDictionary="dustAntimony" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGarnieriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGarnierite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGarnierite" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGarnieriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGarnierite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGarnierite" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="GarnieriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGarnierite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGarnierite" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGarnieriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGarnierite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGarnierite" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGarnieriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGarnierite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGarnierite" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackUraniumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackUranium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedUranium" number="2" />
+        <itemStack oreDictionary="dustLead" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneUraniumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneUranium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedUranium" number="2" />
+        <itemStack oreDictionary="dustLead" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="UraniumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreUranium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedUranium" number="2" />
+        <itemStack oreDictionary="dustLead" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteUraniumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteUranium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedUranium" number="2" />
+        <itemStack oreDictionary="dustLead" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteUraniumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteUranium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedUranium" number="2" />
+        <itemStack oreDictionary="dustLead" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackUraniniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackUraninite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedUraninite" number="2" />
+        <itemStack oreDictionary="dustUranium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneUraniniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneUraninite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedUraninite" number="2" />
+        <itemStack oreDictionary="dustUranium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="UraniniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreUraninite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedUraninite" number="2" />
+        <itemStack oreDictionary="dustUranium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteUraniniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteUraninite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedUraninite" number="2" />
+        <itemStack oreDictionary="dustUranium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteUraniniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteUraninite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedUraninite" number="2" />
+        <itemStack oreDictionary="dustUranium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMagnesiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMagnesite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMagnesite" number="2" />
+        <itemStack oreDictionary="dustMagnesium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMagnesiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMagnesite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMagnesite" number="2" />
+        <itemStack oreDictionary="dustMagnesium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="MagnesiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMagnesite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMagnesite" number="2" />
+        <itemStack oreDictionary="dustMagnesium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMagnesiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMagnesite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMagnesite" number="2" />
+        <itemStack oreDictionary="dustMagnesium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMagnesiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMagnesite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMagnesite" number="2" />
+        <itemStack oreDictionary="dustMagnesium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSaltpeterOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSaltpeter" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSaltpeter" number="8" />
+        <itemStack oreDictionary="dustSaltpeter" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSaltpeterOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSaltpeter" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSaltpeter" number="8" />
+        <itemStack oreDictionary="dustSaltpeter" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SaltpeterOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSaltpeter" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSaltpeter" number="8" />
+        <itemStack oreDictionary="dustSaltpeter" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSaltpeterOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSaltpeter" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSaltpeter" number="8" />
+        <itemStack oreDictionary="dustSaltpeter" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSaltpeterOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSaltpeter" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSaltpeter" number="8" />
+        <itemStack oreDictionary="dustSaltpeter" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackDeshOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackDesh" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedDesh" number="2" />
+        <itemStack oreDictionary="dustDesh" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneDeshOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneDesh" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedDesh" number="2" />
+        <itemStack oreDictionary="dustDesh" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="DeshOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreDesh" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedDesh" number="2" />
+        <itemStack oreDictionary="dustDesh" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteDeshOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteDesh" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedDesh" number="2" />
+        <itemStack oreDictionary="dustDesh" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteDeshOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteDesh" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedDesh" number="2" />
+        <itemStack oreDictionary="dustDesh" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLepidoliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLepidolite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLepidolite" number="2" />
+        <itemStack oreDictionary="dustLithium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLepidoliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLepidolite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLepidolite" number="2" />
+        <itemStack oreDictionary="dustLithium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="LepidoliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreLepidolite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLepidolite" number="2" />
+        <itemStack oreDictionary="dustLithium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteLepidoliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteLepidolite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLepidolite" number="2" />
+        <itemStack oreDictionary="dustLithium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteLepidoliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteLepidolite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLepidolite" number="2" />
+        <itemStack oreDictionary="dustLithium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSpessartineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSpessartine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSpessartine" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSpessartineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSpessartine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSpessartine" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SpessartineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSpessartine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSpessartine" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSpessartineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSpessartine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSpessartine" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSpessartineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSpessartine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSpessartine" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackNetherQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackNetherQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
+        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneNetherQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneNetherQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
+        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
+        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteNetherQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteNetherQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
+        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteNetherQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteNetherQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
+        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPyropeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPyrope" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrope" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePyropeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePyrope" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrope" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="PyropeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePyrope" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrope" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePyropeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePyrope" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrope" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePyropeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePyrope" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrope" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBastnasiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBastnasite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBastnasite" number="2" />
+        <itemStack oreDictionary="dustNeodymium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBastnasiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBastnasite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBastnasite" number="2" />
+        <itemStack oreDictionary="dustNeodymium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BastnasiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBastnasite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBastnasite" number="2" />
+        <itemStack oreDictionary="dustNeodymium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBastnasiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBastnasite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBastnasite" number="2" />
+        <itemStack oreDictionary="dustNeodymium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBastnasiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBastnasite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBastnasite" number="2" />
+        <itemStack oreDictionary="dustNeodymium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackYellowLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackYellowLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedYellowLimonite" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneYellowLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneYellowLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedYellowLimonite" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="YellowLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreYellowLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedYellowLimonite" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteYellowLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteYellowLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedYellowLimonite" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteYellowLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteYellowLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedYellowLimonite" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLeadOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLead" number="2" />
+        <itemStack oreDictionary="dustSilver" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLeadOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLead" number="2" />
+        <itemStack oreDictionary="dustSilver" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="LeadOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLead" number="2" />
+        <itemStack oreDictionary="dustSilver" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteLeadOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLead" number="2" />
+        <itemStack oreDictionary="dustSilver" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteLeadOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLead" number="2" />
+        <itemStack oreDictionary="dustSilver" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCinnabarOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCinnabar" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCinnabar" number="2" />
+        <itemStack oreDictionary="dustRedstone" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCinnabarOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCinnabar" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCinnabar" number="2" />
+        <itemStack oreDictionary="dustRedstone" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="CinnabarOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCinnabar" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCinnabar" number="2" />
+        <itemStack oreDictionary="dustRedstone" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCinnabarOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCinnabar" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCinnabar" number="2" />
+        <itemStack oreDictionary="dustRedstone" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCinnabarOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCinnabar" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCinnabar" number="2" />
+        <itemStack oreDictionary="dustRedstone" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackDiamondOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackDiamond" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedDiamond" number="2" />
+        <itemStack oreDictionary="dustGraphite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneDiamondOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneDiamond" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedDiamond" number="2" />
+        <itemStack oreDictionary="dustGraphite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="DiamondOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreDiamond" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedDiamond" number="2" />
+        <itemStack oreDictionary="dustGraphite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteDiamondOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteDiamond" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedDiamond" number="2" />
+        <itemStack oreDictionary="dustGraphite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteDiamondOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteDiamond" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedDiamond" number="2" />
+        <itemStack oreDictionary="dustGraphite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPhosphateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPhosphate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPhosphate" number="2" />
+        <itemStack oreDictionary="dustPhosphor" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePhosphateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePhosphate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPhosphate" number="2" />
+        <itemStack oreDictionary="dustPhosphor" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="PhosphateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePhosphate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPhosphate" number="2" />
+        <itemStack oreDictionary="dustPhosphor" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePhosphateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePhosphate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPhosphate" number="2" />
+        <itemStack oreDictionary="dustPhosphor" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePhosphateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePhosphate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPhosphate" number="2" />
+        <itemStack oreDictionary="dustPhosphor" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackThoriumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackThorium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedThorium" number="2" />
+        <itemStack oreDictionary="dustUranium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneThoriumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneThorium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedThorium" number="2" />
+        <itemStack oreDictionary="dustUranium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="ThoriumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreThorium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedThorium" number="2" />
+        <itemStack oreDictionary="dustUranium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteThoriumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteThorium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedThorium" number="2" />
+        <itemStack oreDictionary="dustUranium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteThoriumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteThorium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedThorium" number="2" />
+        <itemStack oreDictionary="dustUranium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSulfurOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSulfur" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSulfur" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSulfurOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSulfur" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSulfur" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SulfurOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSulfur" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSulfur" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSulfurOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSulfur" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSulfur" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSulfurOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSulfur" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSulfur" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackFirestoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackFirestone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedFirestone" number="2" />
+        <itemStack oreDictionary="gemFirestone" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneFirestoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneFirestone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedFirestone" number="2" />
+        <itemStack oreDictionary="gemFirestone" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="FirestoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreFirestone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedFirestone" number="2" />
+        <itemStack oreDictionary="gemFirestone" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteFirestoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteFirestone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedFirestone" number="2" />
+        <itemStack oreDictionary="gemFirestone" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteFirestoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteFirestone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedFirestone" number="2" />
+        <itemStack oreDictionary="gemFirestone" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCertusQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCertusQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
+        <itemStack oreDictionary="gemQuartzite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCertusQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCertusQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
+        <itemStack oreDictionary="gemQuartzite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="CertusQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCertusQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
+        <itemStack oreDictionary="gemQuartzite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCertusQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCertusQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
+        <itemStack oreDictionary="gemQuartzite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCertusQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCertusQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
+        <itemStack oreDictionary="gemQuartzite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackIridiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackIridium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIridium" number="2" />
+        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneIridiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneIridium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIridium" number="2" />
+        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="IridiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreIridium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIridium" number="2" />
+        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteIridiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteIridium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIridium" number="2" />
+        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteIridiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteIridium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIridium" number="2" />
+        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPentlanditeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPentlandite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPentlandite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePentlanditeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePentlandite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPentlandite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="PentlanditeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePentlandite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPentlandite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePentlanditeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePentlandite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPentlandite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePentlanditeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePentlandite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPentlandite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackIlmeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackIlmenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIlmenite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneIlmeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneIlmenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIlmenite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="IlmeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreIlmenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIlmenite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteIlmeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteIlmenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIlmenite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteIlmeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteIlmenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIlmenite" number="2" />
+        <itemStack oreDictionary="dustIron" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBariteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBarite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBarite" number="2" />
+        <itemStack oreDictionary="dustBarite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBariteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBarite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBarite" number="2" />
+        <itemStack oreDictionary="dustBarite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BariteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBarite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBarite" number="2" />
+        <itemStack oreDictionary="dustBarite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBariteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBarite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBarite" number="2" />
+        <itemStack oreDictionary="dustBarite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBariteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBarite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBarite" number="2" />
+        <itemStack oreDictionary="dustBarite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrite" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrite" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="PyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrite" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrite" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrite" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMolybdenumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMolybdenum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMolybdenum" number="2" />
+        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMolybdenumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMolybdenum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMolybdenum" number="2" />
+        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="MolybdenumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMolybdenum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMolybdenum" number="2" />
+        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMolybdenumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMolybdenum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMolybdenum" number="2" />
+        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMolybdenumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMolybdenum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMolybdenum" number="2" />
+        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPowelliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPowellite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPowellite" number="2" />
+        <itemStack oreDictionary="dustPowellite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePowelliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePowellite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPowellite" number="2" />
+        <itemStack oreDictionary="dustPowellite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="PowelliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePowellite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPowellite" number="2" />
+        <itemStack oreDictionary="dustPowellite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePowelliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePowellite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPowellite" number="2" />
+        <itemStack oreDictionary="dustPowellite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePowelliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePowellite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPowellite" number="2" />
+        <itemStack oreDictionary="dustPowellite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLigniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLignite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLignite" number="2" />
+        <itemStack oreDictionary="gemCoal" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLigniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLignite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLignite" number="2" />
+        <itemStack oreDictionary="gemCoal" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="LigniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreLignite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLignite" number="2" />
+        <itemStack oreDictionary="gemCoal" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteLigniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteLignite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLignite" number="2" />
+        <itemStack oreDictionary="gemCoal" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteLigniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteLignite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLignite" number="2" />
+        <itemStack oreDictionary="gemCoal" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGlauconiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGlauconite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGlauconite" number="2" />
+        <itemStack oreDictionary="dustSodium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGlauconiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGlauconite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGlauconite" number="2" />
+        <itemStack oreDictionary="dustSodium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="GlauconiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGlauconite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGlauconite" number="2" />
+        <itemStack oreDictionary="dustSodium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGlauconiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGlauconite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGlauconite" number="2" />
+        <itemStack oreDictionary="dustSodium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGlauconiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGlauconite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGlauconite" number="2" />
+        <itemStack oreDictionary="dustSodium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackNickelOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNickel" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneNickelOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNickel" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NickelOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNickel" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteNickelOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNickel" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteNickelOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNickel" number="2" />
+        <itemStack oreDictionary="dustCobalt" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSodaliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSodalite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSodalite" number="12" />
+        <itemStack oreDictionary="gemLazurite" chance="0.4" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSodaliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSodalite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSodalite" number="12" />
+        <itemStack oreDictionary="gemLazurite" chance="0.4" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SodaliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSodalite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSodalite" number="12" />
+        <itemStack oreDictionary="gemLazurite" chance="0.4" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSodaliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSodalite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSodalite" number="12" />
+        <itemStack oreDictionary="gemLazurite" chance="0.4" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSodaliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSodalite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSodalite" number="12" />
+        <itemStack oreDictionary="gemLazurite" chance="0.4" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBauxiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBauxite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBauxite" number="2" />
+        <itemStack oreDictionary="dustGrossular" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBauxiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBauxite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBauxite" number="2" />
+        <itemStack oreDictionary="dustGrossular" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BauxiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBauxite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBauxite" number="2" />
+        <itemStack oreDictionary="dustGrossular" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBauxiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBauxite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBauxite" number="2" />
+        <itemStack oreDictionary="dustGrossular" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBauxiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBauxite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBauxite" number="2" />
+        <itemStack oreDictionary="dustGrossular" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackQuartziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackQuartzite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedQuartzite" number="2" />
+        <itemStack oreDictionary="gemCertusQuartz" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneQuartziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneQuartzite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedQuartzite" number="2" />
+        <itemStack oreDictionary="gemCertusQuartz" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="QuartziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreQuartzite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedQuartzite" number="2" />
+        <itemStack oreDictionary="gemCertusQuartz" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteQuartziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteQuartzite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedQuartzite" number="2" />
+        <itemStack oreDictionary="gemCertusQuartz" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteQuartziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteQuartzite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedQuartzite" number="2" />
+        <itemStack oreDictionary="gemCertusQuartz" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackAluminiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAluminium" number="2" />
+        <itemStack oreDictionary="dustBauxite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneAluminiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAluminium" number="2" />
+        <itemStack oreDictionary="dustBauxite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="AluminiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAluminium" number="2" />
+        <itemStack oreDictionary="dustBauxite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteAluminiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAluminium" number="2" />
+        <itemStack oreDictionary="dustBauxite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteAluminiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAluminium" number="2" />
+        <itemStack oreDictionary="dustBauxite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSilverOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSilver" number="2" />
+        <itemStack oreDictionary="dustLead" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSilverOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSilver" number="2" />
+        <itemStack oreDictionary="dustLead" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SilverOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSilver" number="2" />
+        <itemStack oreDictionary="dustLead" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSilverOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSilver" number="2" />
+        <itemStack oreDictionary="dustLead" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSilverOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSilver" number="2" />
+        <itemStack oreDictionary="dustLead" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBerylliumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBeryllium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBeryllium" number="2" />
+        <itemStack oreDictionary="gemEmerald" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBerylliumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBeryllium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBeryllium" number="2" />
+        <itemStack oreDictionary="gemEmerald" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BerylliumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBeryllium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBeryllium" number="2" />
+        <itemStack oreDictionary="gemEmerald" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBerylliumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBeryllium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBeryllium" number="2" />
+        <itemStack oreDictionary="gemEmerald" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBerylliumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBeryllium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBeryllium" number="2" />
+        <itemStack oreDictionary="gemEmerald" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackApatiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackApatite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedApatite" number="8" />
+        <itemStack oreDictionary="gemPhosphorus" chance="0.2" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneApatiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneApatite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedApatite" number="8" />
+        <itemStack oreDictionary="gemPhosphorus" chance="0.2" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="ApatiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreApatite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedApatite" number="8" />
+        <itemStack oreDictionary="gemPhosphorus" chance="0.2" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteApatiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteApatite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedApatite" number="8" />
+        <itemStack oreDictionary="gemPhosphorus" chance="0.2" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteApatiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteApatite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedApatite" number="8" />
+        <itemStack oreDictionary="gemPhosphorus" chance="0.2" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCheeseOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCheese" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCheese" number="2" />
+        <itemStack oreDictionary="dustCheese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCheeseOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCheese" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCheese" number="2" />
+        <itemStack oreDictionary="dustCheese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="CheeseOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCheese" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCheese" number="2" />
+        <itemStack oreDictionary="dustCheese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCheeseOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCheese" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCheese" number="2" />
+        <itemStack oreDictionary="dustCheese" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCheeseOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCheese" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCheese" number="2" />
+        <itemStack oreDictionary="dustCheese" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGalenaOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGalena" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGalena" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGalenaOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGalena" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGalena" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="GalenaOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGalena" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGalena" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGalenaOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGalena" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGalena" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGalenaOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGalena" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGalena" number="2" />
+        <itemStack oreDictionary="dustSulfur" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackNeodymiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackNeodymium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNeodymium" number="2" />
+        <itemStack oreDictionary="gemMonazite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneNeodymiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneNeodymium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNeodymium" number="2" />
+        <itemStack oreDictionary="gemMonazite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NeodymiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNeodymium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNeodymium" number="2" />
+        <itemStack oreDictionary="gemMonazite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteNeodymiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteNeodymium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNeodymium" number="2" />
+        <itemStack oreDictionary="gemMonazite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteNeodymiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteNeodymium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNeodymium" number="2" />
+        <itemStack oreDictionary="gemMonazite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackAlmandineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackAlmandine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAlmandine" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneAlmandineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneAlmandine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAlmandine" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="AlmandineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreAlmandine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAlmandine" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteAlmandineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteAlmandine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAlmandine" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteAlmandineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteAlmandine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAlmandine" number="2" />
+        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSphaleriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSphalerite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSphalerite" number="2" />
+        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSphaleriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSphalerite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSphalerite" number="2" />
+        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SphaleriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSphalerite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSphalerite" number="2" />
+        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSphaleriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSphalerite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSphalerite" number="2" />
+        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSphaleriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSphalerite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSphalerite" number="2" />
+        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBrownLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBrownLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBrownLimonite" number="2" />
+        <itemStack oreDictionary="dustMalachite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBrownLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBrownLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBrownLimonite" number="2" />
+        <itemStack oreDictionary="dustMalachite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BrownLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBrownLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBrownLimonite" number="2" />
+        <itemStack oreDictionary="dustMalachite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBrownLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBrownLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBrownLimonite" number="2" />
+        <itemStack oreDictionary="dustMalachite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBrownLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBrownLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBrownLimonite" number="2" />
+        <itemStack oreDictionary="dustMalachite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSoapstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSoapstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSoapstone" number="2" />
+        <itemStack oreDictionary="dustSoapstone" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSoapstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSoapstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSoapstone" number="2" />
+        <itemStack oreDictionary="dustSoapstone" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SoapstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSoapstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSoapstone" number="2" />
+        <itemStack oreDictionary="dustSoapstone" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSoapstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSoapstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSoapstone" number="2" />
+        <itemStack oreDictionary="dustSoapstone" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSoapstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSoapstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSoapstone" number="2" />
+        <itemStack oreDictionary="dustSoapstone" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackChalcopyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackChalcopyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedChalcopyrite" number="2" />
+        <itemStack oreDictionary="dustPyrite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneChalcopyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneChalcopyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedChalcopyrite" number="2" />
+        <itemStack oreDictionary="dustPyrite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="ChalcopyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreChalcopyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedChalcopyrite" number="2" />
+        <itemStack oreDictionary="dustPyrite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteChalcopyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteChalcopyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedChalcopyrite" number="2" />
+        <itemStack oreDictionary="dustPyrite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteChalcopyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteChalcopyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedChalcopyrite" number="2" />
+        <itemStack oreDictionary="dustPyrite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPalladiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPalladium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPalladium" number="2" />
+        <itemStack oreDictionary="dustPalladium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePalladiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePalladium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPalladium" number="2" />
+        <itemStack oreDictionary="dustPalladium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="PalladiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePalladium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPalladium" number="2" />
+        <itemStack oreDictionary="dustPalladium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePalladiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePalladium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPalladium" number="2" />
+        <itemStack oreDictionary="dustPalladium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePalladiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePalladium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPalladium" number="2" />
+        <itemStack oreDictionary="dustPalladium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGreenSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGreenSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGreenSapphire" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGreenSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGreenSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGreenSapphire" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="GreenSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGreenSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGreenSapphire" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGreenSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGreenSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGreenSapphire" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGreenSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGreenSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGreenSapphire" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLazuriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLazurite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLazurite" number="12" />
+        <itemStack oreDictionary="gemSodalite" chance="0.4" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLazuriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLazurite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLazurite" number="12" />
+        <itemStack oreDictionary="gemSodalite" chance="0.4" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="LazuriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreLazurite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLazurite" number="12" />
+        <itemStack oreDictionary="gemSodalite" chance="0.4" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteLazuriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteLazurite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLazurite" number="12" />
+        <itemStack oreDictionary="gemSodalite" chance="0.4" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteLazuriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteLazurite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLazurite" number="12" />
+        <itemStack oreDictionary="gemSodalite" chance="0.4" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCassiteriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCassiterite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCassiterite" number="4" />
+        <itemStack oreDictionary="dustTin" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCassiteriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCassiterite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCassiterite" number="4" />
+        <itemStack oreDictionary="dustTin" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="CassiteriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCassiterite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCassiterite" number="4" />
+        <itemStack oreDictionary="dustTin" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCassiteriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCassiterite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCassiterite" number="4" />
+        <itemStack oreDictionary="dustTin" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCassiteriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCassiterite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCassiterite" number="4" />
+        <itemStack oreDictionary="dustTin" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackTantaliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackTantalite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTantalite" number="2" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneTantaliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneTantalite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTantalite" number="2" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="TantaliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreTantalite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTantalite" number="2" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteTantaliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteTantalite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTantalite" number="2" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteTantaliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteTantalite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTantalite" number="2" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackRubyOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackRuby" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRuby" number="2" />
+        <itemStack oreDictionary="dustChrome" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneRubyOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneRuby" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRuby" number="2" />
+        <itemStack oreDictionary="dustChrome" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RubyOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRuby" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRuby" number="2" />
+        <itemStack oreDictionary="dustChrome" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteRubyOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteRuby" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRuby" number="2" />
+        <itemStack oreDictionary="dustChrome" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteRubyOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteRuby" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRuby" number="2" />
+        <itemStack oreDictionary="dustChrome" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPlatinumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPlatinum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPlatinum" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePlatinumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePlatinum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPlatinum" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="PlatinumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePlatinum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPlatinum" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePlatinumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePlatinum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPlatinum" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePlatinumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePlatinum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPlatinum" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGraphiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGraphite" number="2" />
+        <itemStack oreDictionary="dustCarbon" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGraphiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGraphite" number="2" />
+        <itemStack oreDictionary="dustCarbon" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="GraphiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGraphite" number="2" />
+        <itemStack oreDictionary="dustCarbon" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGraphiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGraphite" number="2" />
+        <itemStack oreDictionary="dustCarbon" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGraphiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGraphite" number="2" />
+        <itemStack oreDictionary="dustCarbon" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMolybdeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMolybdenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMolybdenite" number="2" />
+        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMolybdeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMolybdenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMolybdenite" number="2" />
+        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="MolybdeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMolybdenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMolybdenite" number="2" />
+        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMolybdeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMolybdenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMolybdenite" number="2" />
+        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMolybdeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMolybdenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMolybdenite" number="2" />
+        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSpodumeneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSpodumene" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSpodumene" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSpodumeneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSpodumene" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSpodumene" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SpodumeneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSpodumene" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSpodumene" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSpodumeneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSpodumene" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSpodumene" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSpodumeneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSpodumene" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSpodumene" number="2" />
+        <itemStack oreDictionary="dustAluminium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLithiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLithium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLithium" number="2" />
+        <itemStack oreDictionary="dustLithium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLithiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLithium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLithium" number="2" />
+        <itemStack oreDictionary="dustLithium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="LithiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreLithium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLithium" number="2" />
+        <itemStack oreDictionary="dustLithium" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteLithiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteLithium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLithium" number="2" />
+        <itemStack oreDictionary="dustLithium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteLithiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteLithium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedLithium" number="2" />
+        <itemStack oreDictionary="dustLithium" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackTungstateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackTungstate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTungstate" number="4" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneTungstateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneTungstate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTungstate" number="4" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="TungstateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreTungstate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTungstate" number="4" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteTungstateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteTungstate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTungstate" number="4" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteTungstateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteTungstate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedTungstate" number="4" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackWulfeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackWulfenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedWulfenite" number="2" />
+        <itemStack oreDictionary="dustWulfenite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneWulfeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneWulfenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedWulfenite" number="2" />
+        <itemStack oreDictionary="dustWulfenite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="WulfeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreWulfenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedWulfenite" number="2" />
+        <itemStack oreDictionary="dustWulfenite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteWulfeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteWulfenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedWulfenite" number="2" />
+        <itemStack oreDictionary="dustWulfenite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteWulfeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteWulfenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedWulfenite" number="2" />
+        <itemStack oreDictionary="dustWulfenite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGrossularOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGrossular" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGrossular" number="2" />
+        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGrossularOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGrossular" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGrossular" number="2" />
+        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="GrossularOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGrossular" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGrossular" number="2" />
+        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGrossularOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGrossular" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGrossular" number="2" />
+        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGrossularOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGrossular" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGrossular" number="2" />
+        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackAmberOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackAmber" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAmber" number="4" />
+        <itemStack oreDictionary="gemAmber" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneAmberOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneAmber" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAmber" number="4" />
+        <itemStack oreDictionary="gemAmber" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="AmberOre" energyCost="32000">
       <input>
         <itemStack oreDictionary="oreAmber" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedAmber" number="2" />
-        <itemStack oreDictionary="gemChippedAmber" number="1" chance="0.25" />
+        <itemStack oreDictionary="crushedAmber" number="4" />
+        <itemStack oreDictionary="gemAmber" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
       </output>
     </recipe>
-    <recipe name="AmethystOre" energyCost="2400" >
+    <recipe name="RedgraniteAmberOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreAmethyst" />
+        <itemStack oreDictionary="oreRedgraniteAmber" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedAmethyst" number="2" />
-        <itemStack oreDictionary="gemChippedAmethyst" number="1" chance="0.25" />
+        <itemStack oreDictionary="crushedAmber" number="4" />
+        <itemStack oreDictionary="gemAmber" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteAmberOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteAmber" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedAmber" number="4" />
+        <itemStack oreDictionary="gemAmber" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackRockSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackRockSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRockSalt" number="4" />
+        <itemStack oreDictionary="dustSalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneRockSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneRockSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRockSalt" number="4" />
+        <itemStack oreDictionary="dustSalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RockSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRockSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRockSalt" number="4" />
+        <itemStack oreDictionary="dustSalt" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteRockSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteRockSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRockSalt" number="4" />
+        <itemStack oreDictionary="dustSalt" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteRockSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteRockSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedRockSalt" number="4" />
+        <itemStack oreDictionary="dustSalt" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMonaziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMonazite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMonazite" number="16" />
+        <itemStack oreDictionary="dustThorium" chance="0.2" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMonaziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMonazite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMonazite" number="16" />
+        <itemStack oreDictionary="dustThorium" chance="0.2" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="MonaziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMonazite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMonazite" number="16" />
+        <itemStack oreDictionary="dustThorium" chance="0.2" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMonaziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMonazite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMonazite" number="16" />
+        <itemStack oreDictionary="dustThorium" chance="0.2" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMonaziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMonazite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMonazite" number="16" />
+        <itemStack oreDictionary="dustThorium" chance="0.2" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackVanadiumMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackVanadiumMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedVanadiumMagnetite" number="2" />
+        <itemStack oreDictionary="dustMagnetite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneVanadiumMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneVanadiumMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedVanadiumMagnetite" number="2" />
+        <itemStack oreDictionary="dustMagnetite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="VanadiumMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreVanadiumMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedVanadiumMagnetite" number="2" />
+        <itemStack oreDictionary="dustMagnetite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteVanadiumMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteVanadiumMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedVanadiumMagnetite" number="2" />
+        <itemStack oreDictionary="dustMagnetite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteVanadiumMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteVanadiumMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedVanadiumMagnetite" number="2" />
+        <itemStack oreDictionary="dustMagnetite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCoalOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCoal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCoal" number="2" />
+        <itemStack oreDictionary="gemLignite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCoalOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCoal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCoal" number="2" />
+        <itemStack oreDictionary="gemLignite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="CoalOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCoal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCoal" number="2" />
+        <itemStack oreDictionary="gemLignite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCoalOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCoal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCoal" number="2" />
+        <itemStack oreDictionary="gemLignite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCoalOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCoal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCoal" number="2" />
+        <itemStack oreDictionary="gemLignite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSiliconOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSilicon" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSilicon" number="2" />
+        <itemStack oreDictionary="dustSiliconDioxide" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSiliconOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSilicon" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSilicon" number="2" />
+        <itemStack oreDictionary="dustSiliconDioxide" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="SiliconOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSilicon" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSilicon" number="2" />
+        <itemStack oreDictionary="dustSiliconDioxide" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSiliconOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSilicon" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSilicon" number="2" />
+        <itemStack oreDictionary="dustSiliconDioxide" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSiliconOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSilicon" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedSilicon" number="2" />
+        <itemStack oreDictionary="dustSiliconDioxide" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackNaquadahOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackNaquadah" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNaquadah" number="2" />
+        <itemStack oreDictionary="dustNaquadahEnriched" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneNaquadahOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneNaquadah" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNaquadah" number="2" />
+        <itemStack oreDictionary="dustNaquadahEnriched" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NaquadahOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNaquadah" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNaquadah" number="2" />
+        <itemStack oreDictionary="dustNaquadahEnriched" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteNaquadahOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteNaquadah" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNaquadah" number="2" />
+        <itemStack oreDictionary="dustNaquadahEnriched" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteNaquadahOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteNaquadah" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedNaquadah" number="2" />
+        <itemStack oreDictionary="dustNaquadahEnriched" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIron" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIron" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="IronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIron" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIron" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedIron" number="2" />
+        <itemStack oreDictionary="dustNickel" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackStibniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackStibnite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedStibnite" number="2" />
+        <itemStack oreDictionary="dustAntimony" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneStibniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneStibnite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedStibnite" number="2" />
+        <itemStack oreDictionary="dustAntimony" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="StibniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreStibnite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedStibnite" number="2" />
+        <itemStack oreDictionary="dustAntimony" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteStibniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteStibnite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedStibnite" number="2" />
+        <itemStack oreDictionary="dustAntimony" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteStibniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteStibnite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedStibnite" number="2" />
+        <itemStack oreDictionary="dustAntimony" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBandedIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBandedIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBandedIron" number="2" />
+        <itemStack oreDictionary="dustBandedIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBandedIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBandedIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBandedIron" number="2" />
+        <itemStack oreDictionary="dustBandedIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BandedIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBandedIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBandedIron" number="2" />
+        <itemStack oreDictionary="dustBandedIron" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBandedIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBandedIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBandedIron" number="2" />
+        <itemStack oreDictionary="dustBandedIron" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBandedIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBandedIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedBandedIron" number="2" />
+        <itemStack oreDictionary="dustBandedIron" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPhosphorusOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPhosphorus" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPhosphorus" number="6" />
+        <itemStack oreDictionary="gemApatite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePhosphorusOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePhosphorus" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPhosphorus" number="6" />
+        <itemStack oreDictionary="gemApatite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="PhosphorusOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePhosphorus" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPhosphorus" number="6" />
+        <itemStack oreDictionary="gemApatite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePhosphorusOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePhosphorus" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPhosphorus" number="6" />
+        <itemStack oreDictionary="gemApatite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePhosphorusOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePhosphorus" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPhosphorus" number="6" />
+        <itemStack oreDictionary="gemApatite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCalciteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCalcite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCalcite" number="2" />
+        <itemStack oreDictionary="dustAndradite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCalciteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCalcite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCalcite" number="2" />
+        <itemStack oreDictionary="dustAndradite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="CalciteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCalcite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCalcite" number="2" />
+        <itemStack oreDictionary="dustAndradite" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCalciteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCalcite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCalcite" number="2" />
+        <itemStack oreDictionary="dustAndradite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCalciteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCalcite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedCalcite" number="2" />
+        <itemStack oreDictionary="dustAndradite" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGoldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGold" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGold" number="2" />
+        <itemStack oreDictionary="dustCopper" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGoldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGold" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGold" number="2" />
+        <itemStack oreDictionary="dustCopper" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="GoldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGold" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGold" number="2" />
+        <itemStack oreDictionary="dustCopper" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGoldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGold" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGold" number="2" />
+        <itemStack oreDictionary="dustCopper" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGoldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGold" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedGold" number="2" />
+        <itemStack oreDictionary="dustCopper" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMalachiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMalachite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMalachite" number="2" />
+        <itemStack oreDictionary="dustCopper" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMalachiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMalachite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMalachite" number="2" />
+        <itemStack oreDictionary="dustCopper" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="MalachiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMalachite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMalachite" number="2" />
+        <itemStack oreDictionary="dustCopper" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMalachiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMalachite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMalachite" number="2" />
+        <itemStack oreDictionary="dustCopper" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMalachiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMalachite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedMalachite" number="2" />
+        <itemStack oreDictionary="dustCopper" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPyrolusiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPyrolusite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrolusite" number="2" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePyrolusiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePyrolusite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrolusite" number="2" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="PyrolusiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePyrolusite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrolusite" number="2" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePyrolusiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePyrolusite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrolusite" number="2" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePyrolusiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePyrolusite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedPyrolusite" number="2" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackScheeliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackScheelite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedScheelite" number="4" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneScheeliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneScheelite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedScheelite" number="4" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="ScheeliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreScheelite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedScheelite" number="4" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteScheeliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteScheelite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedScheelite" number="4" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteScheeliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteScheelite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="crushedScheelite" number="4" />
+        <itemStack oreDictionary="dustManganese" chance="0.1" />
+        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
       </output>
     </recipe>
   </recipeGroup>

--- a/config/enderio/SAGMillRecipes_User.xml
+++ b/config/enderio/SAGMillRecipes_User.xml
@@ -151,6 +151,12 @@ found in the core file.
     <recipe name="Sulfur Ore" />
     <recipe name="Saltpeter" />
   </recipeGroup>
+  
+  <recipeGroup name="Forestry" >
+    <recipe name="ApatiteOre" />
+  </recipeGroup>
+
+  <recipeGroup name="Mekanism" enabled="false" />
 
   <recipeGroup name="GT Ores">
     <recipe name="NetherrackTinOre" energyCost="32000">

--- a/config/enderio/SAGMillRecipes_User.xml
+++ b/config/enderio/SAGMillRecipes_User.xml
@@ -138,7 +138,7 @@ found in the core file.
     <recipe name="LapisLazuliOre" />
     <recipe name="Quartz Ore" />
   </recipeGroup>
-  
+
   <recipeGroup name="Applied Energistics 2">
     <recipe name="ChargedCertusQuartzOre" />
     <recipe name="CertusQuartzOre" />
@@ -156,7 +156,7 @@ found in the core file.
     <recipe name="Sulfur Ore" />
     <recipe name="Saltpeter" />
   </recipeGroup>
-  
+
   <recipeGroup name="Forestry" >
     <recipe name="ApatiteOre" />
   </recipeGroup>
@@ -164,2114 +164,15 @@ found in the core file.
   <recipeGroup name="Mekanism" enabled="false" />
 
   <recipeGroup name="GT Ores">
-    <recipe name="NetherrackTinOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackTin" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTin" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneTinOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneTin" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTin" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="TinOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreTin" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTin" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteTinOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteTin" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTin" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteTinOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteTin" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTin" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackRedstoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackRedstone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRedstone" number="10" />
-        <itemStack oreDictionary="dustCinnabar" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneRedstoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneRedstone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRedstone" number="10" />
-        <itemStack oreDictionary="dustCinnabar" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedstoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedstone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRedstone" number="10" />
-        <itemStack oreDictionary="dustCinnabar" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteRedstoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteRedstone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRedstone" number="10" />
-        <itemStack oreDictionary="dustCinnabar" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteRedstoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteRedstone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRedstone" number="10" />
-        <itemStack oreDictionary="dustCinnabar" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackEmeraldOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackEmerald" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedEmerald" number="2" />
-        <itemStack oreDictionary="dustBeryllium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneEmeraldOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneEmerald" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedEmerald" number="2" />
-        <itemStack oreDictionary="dustBeryllium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EmeraldOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEmerald" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedEmerald" number="2" />
-        <itemStack oreDictionary="dustBeryllium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteEmeraldOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteEmerald" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedEmerald" number="2" />
-        <itemStack oreDictionary="dustBeryllium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteEmeraldOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteEmerald" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedEmerald" number="2" />
-        <itemStack oreDictionary="dustBeryllium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackLapisOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackLapis" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLapis" number="12" />
-        <itemStack oreDictionary="gemLazurite" chance="0.4" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneLapisOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneLapis" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLapis" number="12" />
-        <itemStack oreDictionary="gemLazurite" chance="0.4" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="LapisOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreLapis" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLapis" number="12" />
-        <itemStack oreDictionary="gemLazurite" chance="0.4" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteLapisOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteLapis" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLapis" number="12" />
-        <itemStack oreDictionary="gemLazurite" chance="0.4" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteLapisOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteLapis" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLapis" number="12" />
-        <itemStack oreDictionary="gemLazurite" chance="0.4" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackCobaltiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackCobaltite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCobaltite" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneCobaltiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneCobaltite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCobaltite" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="CobaltiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreCobaltite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCobaltite" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteCobaltiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteCobaltite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCobaltite" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteCobaltiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteCobaltite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCobaltite" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackSapphireOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackSapphire" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSapphire" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneSapphireOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneSapphire" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSapphire" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="SapphireOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreSapphire" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSapphire" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteSapphireOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteSapphire" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSapphire" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteSapphireOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteSapphire" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSapphire" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackMagnetiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackMagnetite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMagnetite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneMagnetiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneMagnetite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMagnetite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="MagnetiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreMagnetite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMagnetite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteMagnetiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteMagnetite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMagnetite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteMagnetiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteMagnetite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMagnetite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackCopperOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackCopper" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCopper" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneCopperOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneCopper" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCopper" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="CopperOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreCopper" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCopper" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteCopperOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteCopper" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCopper" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteCopperOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteCopper" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCopper" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackCooperiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackCooperite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCooperite" number="2" />
-        <itemStack oreDictionary="dustPalladium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneCooperiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneCooperite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCooperite" number="2" />
-        <itemStack oreDictionary="dustPalladium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="CooperiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreCooperite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCooperite" number="2" />
-        <itemStack oreDictionary="dustPalladium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteCooperiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteCooperite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCooperite" number="2" />
-        <itemStack oreDictionary="dustPalladium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteCooperiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteCooperite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCooperite" number="2" />
-        <itemStack oreDictionary="dustPalladium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackSaltOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackSalt" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSalt" number="4" />
-        <itemStack oreDictionary="dustRockSalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneSaltOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneSalt" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSalt" number="4" />
-        <itemStack oreDictionary="dustRockSalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="SaltOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreSalt" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSalt" number="4" />
-        <itemStack oreDictionary="dustRockSalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteSaltOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteSalt" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSalt" number="4" />
-        <itemStack oreDictionary="dustRockSalt" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteSaltOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteSalt" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSalt" number="4" />
-        <itemStack oreDictionary="dustRockSalt" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackOlivineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackOlivine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedOlivine" number="2" />
-        <itemStack oreDictionary="dustPyrope" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneOlivineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneOlivine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedOlivine" number="2" />
-        <itemStack oreDictionary="dustPyrope" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="OlivineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreOlivine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedOlivine" number="2" />
-        <itemStack oreDictionary="dustPyrope" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteOlivineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteOlivine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedOlivine" number="2" />
-        <itemStack oreDictionary="dustPyrope" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteOlivineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteOlivine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedOlivine" number="2" />
-        <itemStack oreDictionary="dustPyrope" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackTetrahedriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackTetrahedrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTetrahedrite" number="2" />
-        <itemStack oreDictionary="dustAntimony" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneTetrahedriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneTetrahedrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTetrahedrite" number="2" />
-        <itemStack oreDictionary="dustAntimony" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="TetrahedriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreTetrahedrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTetrahedrite" number="2" />
-        <itemStack oreDictionary="dustAntimony" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteTetrahedriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteTetrahedrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTetrahedrite" number="2" />
-        <itemStack oreDictionary="dustAntimony" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteTetrahedriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteTetrahedrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTetrahedrite" number="2" />
-        <itemStack oreDictionary="dustAntimony" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackGarnieriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackGarnierite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGarnierite" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneGarnieriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneGarnierite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGarnierite" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="GarnieriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreGarnierite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGarnierite" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteGarnieriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteGarnierite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGarnierite" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteGarnieriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteGarnierite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGarnierite" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackUraniumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackUranium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedUranium" number="2" />
-        <itemStack oreDictionary="dustLead" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneUraniumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneUranium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedUranium" number="2" />
-        <itemStack oreDictionary="dustLead" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="UraniumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreUranium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedUranium" number="2" />
-        <itemStack oreDictionary="dustLead" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteUraniumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteUranium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedUranium" number="2" />
-        <itemStack oreDictionary="dustLead" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteUraniumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteUranium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedUranium" number="2" />
-        <itemStack oreDictionary="dustLead" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackUraniniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackUraninite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedUraninite" number="2" />
-        <itemStack oreDictionary="dustUranium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneUraniniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneUraninite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedUraninite" number="2" />
-        <itemStack oreDictionary="dustUranium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="UraniniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreUraninite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedUraninite" number="2" />
-        <itemStack oreDictionary="dustUranium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteUraniniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteUraninite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedUraninite" number="2" />
-        <itemStack oreDictionary="dustUranium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteUraniniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteUraninite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedUraninite" number="2" />
-        <itemStack oreDictionary="dustUranium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackMagnesiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackMagnesite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMagnesite" number="2" />
-        <itemStack oreDictionary="dustMagnesium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneMagnesiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneMagnesite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMagnesite" number="2" />
-        <itemStack oreDictionary="dustMagnesium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="MagnesiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreMagnesite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMagnesite" number="2" />
-        <itemStack oreDictionary="dustMagnesium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteMagnesiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteMagnesite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMagnesite" number="2" />
-        <itemStack oreDictionary="dustMagnesium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteMagnesiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteMagnesite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMagnesite" number="2" />
-        <itemStack oreDictionary="dustMagnesium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackSaltpeterOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackSaltpeter" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSaltpeter" number="8" />
-        <itemStack oreDictionary="dustSaltpeter" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneSaltpeterOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneSaltpeter" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSaltpeter" number="8" />
-        <itemStack oreDictionary="dustSaltpeter" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="SaltpeterOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreSaltpeter" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSaltpeter" number="8" />
-        <itemStack oreDictionary="dustSaltpeter" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteSaltpeterOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteSaltpeter" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSaltpeter" number="8" />
-        <itemStack oreDictionary="dustSaltpeter" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteSaltpeterOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteSaltpeter" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSaltpeter" number="8" />
-        <itemStack oreDictionary="dustSaltpeter" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackDeshOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackDesh" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedDesh" number="2" />
-        <itemStack oreDictionary="dustDesh" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneDeshOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneDesh" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedDesh" number="2" />
-        <itemStack oreDictionary="dustDesh" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="DeshOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreDesh" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedDesh" number="2" />
-        <itemStack oreDictionary="dustDesh" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteDeshOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteDesh" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedDesh" number="2" />
-        <itemStack oreDictionary="dustDesh" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteDeshOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteDesh" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedDesh" number="2" />
-        <itemStack oreDictionary="dustDesh" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackLepidoliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackLepidolite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLepidolite" number="2" />
-        <itemStack oreDictionary="dustLithium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneLepidoliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneLepidolite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLepidolite" number="2" />
-        <itemStack oreDictionary="dustLithium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="LepidoliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreLepidolite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLepidolite" number="2" />
-        <itemStack oreDictionary="dustLithium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteLepidoliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteLepidolite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLepidolite" number="2" />
-        <itemStack oreDictionary="dustLithium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteLepidoliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteLepidolite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLepidolite" number="2" />
-        <itemStack oreDictionary="dustLithium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackSpessartineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackSpessartine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSpessartine" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneSpessartineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneSpessartine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSpessartine" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="SpessartineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreSpessartine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSpessartine" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteSpessartineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteSpessartine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSpessartine" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteSpessartineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteSpessartine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSpessartine" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackNetherQuartzOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackNetherQuartz" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
-        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneNetherQuartzOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneNetherQuartz" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
-        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherQuartzOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherQuartz" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
-        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteNetherQuartzOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteNetherQuartz" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
-        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteNetherQuartzOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteNetherQuartz" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNetherQuartz" number="4" />
-        <itemStack oreDictionary="dustNetherrack" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackPyropeOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackPyrope" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPyrope" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstonePyropeOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstonePyrope" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPyrope" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="PyropeOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="orePyrope" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPyrope" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgranitePyropeOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgranitePyrope" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPyrope" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgranitePyropeOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgranitePyrope" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPyrope" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackBastnasiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackBastnasite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBastnasite" number="2" />
-        <itemStack oreDictionary="dustNeodymium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneBastnasiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneBastnasite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBastnasite" number="2" />
-        <itemStack oreDictionary="dustNeodymium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BastnasiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBastnasite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBastnasite" number="2" />
-        <itemStack oreDictionary="dustNeodymium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteBastnasiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteBastnasite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBastnasite" number="2" />
-        <itemStack oreDictionary="dustNeodymium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteBastnasiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteBastnasite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBastnasite" number="2" />
-        <itemStack oreDictionary="dustNeodymium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackYellowLimoniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackYellowLimonite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedYellowLimonite" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneYellowLimoniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneYellowLimonite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedYellowLimonite" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="YellowLimoniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreYellowLimonite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedYellowLimonite" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteYellowLimoniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteYellowLimonite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedYellowLimonite" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteYellowLimoniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteYellowLimonite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedYellowLimonite" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackLeadOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackLead" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLead" number="2" />
-        <itemStack oreDictionary="dustSilver" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneLeadOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneLead" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLead" number="2" />
-        <itemStack oreDictionary="dustSilver" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="LeadOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreLead" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLead" number="2" />
-        <itemStack oreDictionary="dustSilver" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteLeadOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteLead" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLead" number="2" />
-        <itemStack oreDictionary="dustSilver" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteLeadOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteLead" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLead" number="2" />
-        <itemStack oreDictionary="dustSilver" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackCinnabarOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackCinnabar" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCinnabar" number="2" />
-        <itemStack oreDictionary="dustRedstone" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneCinnabarOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneCinnabar" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCinnabar" number="2" />
-        <itemStack oreDictionary="dustRedstone" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="CinnabarOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreCinnabar" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCinnabar" number="2" />
-        <itemStack oreDictionary="dustRedstone" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteCinnabarOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteCinnabar" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCinnabar" number="2" />
-        <itemStack oreDictionary="dustRedstone" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteCinnabarOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteCinnabar" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCinnabar" number="2" />
-        <itemStack oreDictionary="dustRedstone" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackDiamondOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackDiamond" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedDiamond" number="2" />
-        <itemStack oreDictionary="dustGraphite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneDiamondOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneDiamond" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedDiamond" number="2" />
-        <itemStack oreDictionary="dustGraphite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="DiamondOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreDiamond" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedDiamond" number="2" />
-        <itemStack oreDictionary="dustGraphite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteDiamondOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteDiamond" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedDiamond" number="2" />
-        <itemStack oreDictionary="dustGraphite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteDiamondOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteDiamond" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedDiamond" number="2" />
-        <itemStack oreDictionary="dustGraphite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackPhosphateOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackPhosphate" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPhosphate" number="2" />
-        <itemStack oreDictionary="dustPhosphor" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstonePhosphateOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstonePhosphate" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPhosphate" number="2" />
-        <itemStack oreDictionary="dustPhosphor" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="PhosphateOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="orePhosphate" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPhosphate" number="2" />
-        <itemStack oreDictionary="dustPhosphor" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgranitePhosphateOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgranitePhosphate" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPhosphate" number="2" />
-        <itemStack oreDictionary="dustPhosphor" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgranitePhosphateOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgranitePhosphate" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPhosphate" number="2" />
-        <itemStack oreDictionary="dustPhosphor" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackThoriumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackThorium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedThorium" number="2" />
-        <itemStack oreDictionary="dustUranium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneThoriumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneThorium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedThorium" number="2" />
-        <itemStack oreDictionary="dustUranium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="ThoriumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreThorium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedThorium" number="2" />
-        <itemStack oreDictionary="dustUranium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteThoriumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteThorium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedThorium" number="2" />
-        <itemStack oreDictionary="dustUranium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteThoriumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteThorium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedThorium" number="2" />
-        <itemStack oreDictionary="dustUranium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackSulfurOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackSulfur" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSulfur" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneSulfurOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneSulfur" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSulfur" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="SulfurOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreSulfur" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSulfur" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteSulfurOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteSulfur" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSulfur" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteSulfurOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteSulfur" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSulfur" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackFirestoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackFirestone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedFirestone" number="2" />
-        <itemStack oreDictionary="gemFirestone" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneFirestoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneFirestone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedFirestone" number="2" />
-        <itemStack oreDictionary="gemFirestone" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="FirestoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreFirestone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedFirestone" number="2" />
-        <itemStack oreDictionary="gemFirestone" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteFirestoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteFirestone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedFirestone" number="2" />
-        <itemStack oreDictionary="gemFirestone" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteFirestoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteFirestone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedFirestone" number="2" />
-        <itemStack oreDictionary="gemFirestone" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackCertusQuartzOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackCertusQuartz" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
-        <itemStack oreDictionary="gemQuartzite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneCertusQuartzOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneCertusQuartz" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
-        <itemStack oreDictionary="gemQuartzite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="CertusQuartzOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreCertusQuartz" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
-        <itemStack oreDictionary="gemQuartzite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteCertusQuartzOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteCertusQuartz" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
-        <itemStack oreDictionary="gemQuartzite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteCertusQuartzOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteCertusQuartz" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCertusQuartz" number="4" />
-        <itemStack oreDictionary="gemQuartzite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackIridiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackIridium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIridium" number="2" />
-        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneIridiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneIridium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIridium" number="2" />
-        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="IridiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreIridium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIridium" number="2" />
-        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteIridiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteIridium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIridium" number="2" />
-        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteIridiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteIridium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIridium" number="2" />
-        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackPentlanditeOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackPentlandite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPentlandite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstonePentlanditeOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstonePentlandite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPentlandite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="PentlanditeOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="orePentlandite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPentlandite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgranitePentlanditeOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgranitePentlandite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPentlandite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgranitePentlanditeOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgranitePentlandite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPentlandite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackIlmeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackIlmenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIlmenite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneIlmeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneIlmenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIlmenite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="IlmeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreIlmenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIlmenite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteIlmeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteIlmenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIlmenite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteIlmeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteIlmenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIlmenite" number="2" />
-        <itemStack oreDictionary="dustIron" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackBariteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackBarite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBarite" number="2" />
-        <itemStack oreDictionary="dustBarite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneBariteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneBarite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBarite" number="2" />
-        <itemStack oreDictionary="dustBarite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BariteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBarite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBarite" number="2" />
-        <itemStack oreDictionary="dustBarite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteBariteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteBarite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBarite" number="2" />
-        <itemStack oreDictionary="dustBarite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteBariteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteBarite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBarite" number="2" />
-        <itemStack oreDictionary="dustBarite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackPyriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackPyrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPyrite" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstonePyriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstonePyrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPyrite" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="PyriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="orePyrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPyrite" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgranitePyriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgranitePyrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPyrite" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgranitePyriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgranitePyrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPyrite" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackMolybdenumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackMolybdenum" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMolybdenum" number="2" />
-        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneMolybdenumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneMolybdenum" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMolybdenum" number="2" />
-        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="MolybdenumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreMolybdenum" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMolybdenum" number="2" />
-        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteMolybdenumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteMolybdenum" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMolybdenum" number="2" />
-        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteMolybdenumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteMolybdenum" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMolybdenum" number="2" />
-        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackPowelliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackPowellite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPowellite" number="2" />
-        <itemStack oreDictionary="dustPowellite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstonePowelliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstonePowellite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPowellite" number="2" />
-        <itemStack oreDictionary="dustPowellite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="PowelliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="orePowellite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPowellite" number="2" />
-        <itemStack oreDictionary="dustPowellite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgranitePowelliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgranitePowellite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPowellite" number="2" />
-        <itemStack oreDictionary="dustPowellite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgranitePowelliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgranitePowellite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPowellite" number="2" />
-        <itemStack oreDictionary="dustPowellite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackLigniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackLignite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLignite" number="2" />
-        <itemStack oreDictionary="gemCoal" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneLigniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneLignite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLignite" number="2" />
-        <itemStack oreDictionary="gemCoal" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="LigniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreLignite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLignite" number="2" />
-        <itemStack oreDictionary="gemCoal" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteLigniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteLignite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLignite" number="2" />
-        <itemStack oreDictionary="gemCoal" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteLigniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteLignite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLignite" number="2" />
-        <itemStack oreDictionary="gemCoal" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackGlauconiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackGlauconite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGlauconite" number="2" />
-        <itemStack oreDictionary="dustSodium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneGlauconiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneGlauconite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGlauconite" number="2" />
-        <itemStack oreDictionary="dustSodium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="GlauconiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreGlauconite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGlauconite" number="2" />
-        <itemStack oreDictionary="dustSodium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteGlauconiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteGlauconite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGlauconite" number="2" />
-        <itemStack oreDictionary="dustSodium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteGlauconiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteGlauconite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGlauconite" number="2" />
-        <itemStack oreDictionary="dustSodium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackNickelOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackNickel" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNickel" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneNickelOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneNickel" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNickel" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NickelOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNickel" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNickel" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteNickelOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteNickel" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNickel" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteNickelOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteNickel" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNickel" number="2" />
-        <itemStack oreDictionary="dustCobalt" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
     <recipe name="NetherrackSodaliteOre" energyCost="32000">
       <input>
         <itemStack oreDictionary="oreNetherrackSodalite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedSodalite" number="12" />
-        <itemStack oreDictionary="gemLazurite" chance="0.4" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallSodalite" number="6" />
+        <itemStack oreDictionary="crushedLazurite" number="4" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
       </output>
     </recipe>
     <recipe name="EndstoneSodaliteOre" energyCost="32000">
@@ -2279,9 +180,10 @@ found in the core file.
         <itemStack oreDictionary="oreEndstoneSodalite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedSodalite" number="12" />
-        <itemStack oreDictionary="gemLazurite" chance="0.4" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallSodalite" number="6" />
+        <itemStack oreDictionary="crushedLazurite" number="4" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
       </output>
     </recipe>
     <recipe name="SodaliteOre" energyCost="32000">
@@ -2289,9 +191,10 @@ found in the core file.
         <itemStack oreDictionary="oreSodalite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedSodalite" number="12" />
-        <itemStack oreDictionary="gemLazurite" chance="0.4" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallSodalite" number="6" />
+        <itemStack oreDictionary="crushedLazurite" number="4" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
       </output>
     </recipe>
     <recipe name="RedgraniteSodaliteOre" energyCost="32000">
@@ -2299,9 +202,10 @@ found in the core file.
         <itemStack oreDictionary="oreRedgraniteSodalite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedSodalite" number="12" />
-        <itemStack oreDictionary="gemLazurite" chance="0.4" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallSodalite" number="6" />
+        <itemStack oreDictionary="crushedLazurite" number="4" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSodaliteOre" energyCost="32000">
@@ -2309,1359 +213,120 @@ found in the core file.
         <itemStack oreDictionary="oreBlackgraniteSodalite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedSodalite" number="12" />
-        <itemStack oreDictionary="gemLazurite" chance="0.4" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallSodalite" number="6" />
+        <itemStack oreDictionary="crushedLazurite" number="4" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="NetherrackBauxiteOre" energyCost="32000">
+    <recipe name="NetherrackThoriumOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreNetherrackBauxite" />
+        <itemStack oreDictionary="oreNetherrackThorium" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedBauxite" number="2" />
-        <itemStack oreDictionary="dustGrossular" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallThorium" number="1" />
+        <itemStack oreDictionary="crushedUranium" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="EndstoneBauxiteOre" energyCost="32000">
+    <recipe name="EndstoneThoriumOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreEndstoneBauxite" />
+        <itemStack oreDictionary="oreEndstoneThorium" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedBauxite" number="2" />
-        <itemStack oreDictionary="dustGrossular" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallThorium" number="1" />
+        <itemStack oreDictionary="crushedUranium" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="BauxiteOre" energyCost="32000">
+    <recipe name="ThoriumOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreBauxite" />
+        <itemStack oreDictionary="oreThorium" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedBauxite" number="2" />
-        <itemStack oreDictionary="dustGrossular" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallThorium" number="1" />
+        <itemStack oreDictionary="crushedUranium" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="RedgraniteBauxiteOre" energyCost="32000">
+    <recipe name="RedgraniteThoriumOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreRedgraniteBauxite" />
+        <itemStack oreDictionary="oreRedgraniteThorium" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedBauxite" number="2" />
-        <itemStack oreDictionary="dustGrossular" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallThorium" number="1" />
+        <itemStack oreDictionary="crushedUranium" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="BlackgraniteBauxiteOre" energyCost="32000">
+    <recipe name="BlackgraniteThoriumOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreBlackgraniteBauxite" />
+        <itemStack oreDictionary="oreBlackgraniteThorium" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedBauxite" number="2" />
-        <itemStack oreDictionary="dustGrossular" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallThorium" number="1" />
+        <itemStack oreDictionary="crushedUranium" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="NetherrackQuartziteOre" energyCost="32000">
+    <recipe name="NetherrackPyriteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreNetherrackQuartzite" />
+        <itemStack oreDictionary="oreNetherrackPyrite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedQuartzite" number="2" />
-        <itemStack oreDictionary="gemCertusQuartz" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPyrite" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="EndstoneQuartziteOre" energyCost="32000">
+    <recipe name="EndstonePyriteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreEndstoneQuartzite" />
+        <itemStack oreDictionary="oreEndstonePyrite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedQuartzite" number="2" />
-        <itemStack oreDictionary="gemCertusQuartz" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPyrite" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="QuartziteOre" energyCost="32000">
+    <recipe name="PyriteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreQuartzite" />
+        <itemStack oreDictionary="orePyrite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedQuartzite" number="2" />
-        <itemStack oreDictionary="gemCertusQuartz" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPyrite" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="RedgraniteQuartziteOre" energyCost="32000">
+    <recipe name="RedgranitePyriteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreRedgraniteQuartzite" />
+        <itemStack oreDictionary="oreRedgranitePyrite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedQuartzite" number="2" />
-        <itemStack oreDictionary="gemCertusQuartz" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPyrite" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="BlackgraniteQuartziteOre" energyCost="32000">
+    <recipe name="BlackgranitePyriteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreBlackgraniteQuartzite" />
+        <itemStack oreDictionary="oreBlackgranitePyrite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedQuartzite" number="2" />
-        <itemStack oreDictionary="gemCertusQuartz" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackAluminiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackAluminium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedAluminium" number="2" />
-        <itemStack oreDictionary="dustBauxite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneAluminiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneAluminium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedAluminium" number="2" />
-        <itemStack oreDictionary="dustBauxite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="AluminiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreAluminium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedAluminium" number="2" />
-        <itemStack oreDictionary="dustBauxite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteAluminiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteAluminium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedAluminium" number="2" />
-        <itemStack oreDictionary="dustBauxite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteAluminiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteAluminium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedAluminium" number="2" />
-        <itemStack oreDictionary="dustBauxite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackSilverOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackSilver" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSilver" number="2" />
-        <itemStack oreDictionary="dustLead" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneSilverOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneSilver" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSilver" number="2" />
-        <itemStack oreDictionary="dustLead" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="SilverOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreSilver" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSilver" number="2" />
-        <itemStack oreDictionary="dustLead" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteSilverOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteSilver" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSilver" number="2" />
-        <itemStack oreDictionary="dustLead" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteSilverOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteSilver" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSilver" number="2" />
-        <itemStack oreDictionary="dustLead" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackBerylliumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackBeryllium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBeryllium" number="2" />
-        <itemStack oreDictionary="gemEmerald" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneBerylliumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneBeryllium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBeryllium" number="2" />
-        <itemStack oreDictionary="gemEmerald" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BerylliumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBeryllium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBeryllium" number="2" />
-        <itemStack oreDictionary="gemEmerald" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteBerylliumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteBeryllium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBeryllium" number="2" />
-        <itemStack oreDictionary="gemEmerald" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteBerylliumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteBeryllium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBeryllium" number="2" />
-        <itemStack oreDictionary="gemEmerald" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackApatiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackApatite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedApatite" number="8" />
-        <itemStack oreDictionary="gemPhosphorus" chance="0.2" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneApatiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneApatite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedApatite" number="8" />
-        <itemStack oreDictionary="gemPhosphorus" chance="0.2" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="ApatiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreApatite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedApatite" number="8" />
-        <itemStack oreDictionary="gemPhosphorus" chance="0.2" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteApatiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteApatite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedApatite" number="8" />
-        <itemStack oreDictionary="gemPhosphorus" chance="0.2" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteApatiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteApatite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedApatite" number="8" />
-        <itemStack oreDictionary="gemPhosphorus" chance="0.2" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackCheeseOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackCheese" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCheese" number="2" />
-        <itemStack oreDictionary="dustCheese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneCheeseOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneCheese" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCheese" number="2" />
-        <itemStack oreDictionary="dustCheese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="CheeseOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreCheese" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCheese" number="2" />
-        <itemStack oreDictionary="dustCheese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteCheeseOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteCheese" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCheese" number="2" />
-        <itemStack oreDictionary="dustCheese" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteCheeseOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteCheese" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCheese" number="2" />
-        <itemStack oreDictionary="dustCheese" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackGalenaOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackGalena" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGalena" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneGalenaOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneGalena" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGalena" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="GalenaOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreGalena" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGalena" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteGalenaOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteGalena" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGalena" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteGalenaOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteGalena" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGalena" number="2" />
-        <itemStack oreDictionary="dustSulfur" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackNeodymiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackNeodymium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNeodymium" number="2" />
-        <itemStack oreDictionary="gemMonazite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneNeodymiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneNeodymium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNeodymium" number="2" />
-        <itemStack oreDictionary="gemMonazite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NeodymiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNeodymium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNeodymium" number="2" />
-        <itemStack oreDictionary="gemMonazite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteNeodymiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteNeodymium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNeodymium" number="2" />
-        <itemStack oreDictionary="gemMonazite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteNeodymiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteNeodymium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNeodymium" number="2" />
-        <itemStack oreDictionary="gemMonazite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackAlmandineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackAlmandine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedAlmandine" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneAlmandineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneAlmandine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedAlmandine" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="AlmandineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreAlmandine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedAlmandine" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteAlmandineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteAlmandine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedAlmandine" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteAlmandineOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteAlmandine" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedAlmandine" number="2" />
-        <itemStack oreDictionary="gemGarnetRed" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackSphaleriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackSphalerite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSphalerite" number="2" />
-        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneSphaleriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneSphalerite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSphalerite" number="2" />
-        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="SphaleriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreSphalerite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSphalerite" number="2" />
-        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteSphaleriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteSphalerite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSphalerite" number="2" />
-        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteSphaleriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteSphalerite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSphalerite" number="2" />
-        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackBrownLimoniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackBrownLimonite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBrownLimonite" number="2" />
-        <itemStack oreDictionary="dustMalachite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneBrownLimoniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneBrownLimonite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBrownLimonite" number="2" />
-        <itemStack oreDictionary="dustMalachite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BrownLimoniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBrownLimonite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBrownLimonite" number="2" />
-        <itemStack oreDictionary="dustMalachite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteBrownLimoniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteBrownLimonite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBrownLimonite" number="2" />
-        <itemStack oreDictionary="dustMalachite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteBrownLimoniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteBrownLimonite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBrownLimonite" number="2" />
-        <itemStack oreDictionary="dustMalachite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackSoapstoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackSoapstone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSoapstone" number="2" />
-        <itemStack oreDictionary="dustSoapstone" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneSoapstoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneSoapstone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSoapstone" number="2" />
-        <itemStack oreDictionary="dustSoapstone" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="SoapstoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreSoapstone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSoapstone" number="2" />
-        <itemStack oreDictionary="dustSoapstone" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteSoapstoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteSoapstone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSoapstone" number="2" />
-        <itemStack oreDictionary="dustSoapstone" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteSoapstoneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteSoapstone" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSoapstone" number="2" />
-        <itemStack oreDictionary="dustSoapstone" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackChalcopyriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackChalcopyrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedChalcopyrite" number="2" />
-        <itemStack oreDictionary="dustPyrite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneChalcopyriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneChalcopyrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedChalcopyrite" number="2" />
-        <itemStack oreDictionary="dustPyrite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="ChalcopyriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreChalcopyrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedChalcopyrite" number="2" />
-        <itemStack oreDictionary="dustPyrite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteChalcopyriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteChalcopyrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedChalcopyrite" number="2" />
-        <itemStack oreDictionary="dustPyrite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteChalcopyriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteChalcopyrite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedChalcopyrite" number="2" />
-        <itemStack oreDictionary="dustPyrite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackPalladiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackPalladium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPalladium" number="2" />
-        <itemStack oreDictionary="dustPalladium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstonePalladiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstonePalladium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPalladium" number="2" />
-        <itemStack oreDictionary="dustPalladium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="PalladiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="orePalladium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPalladium" number="2" />
-        <itemStack oreDictionary="dustPalladium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgranitePalladiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgranitePalladium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPalladium" number="2" />
-        <itemStack oreDictionary="dustPalladium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgranitePalladiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgranitePalladium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPalladium" number="2" />
-        <itemStack oreDictionary="dustPalladium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackGreenSapphireOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackGreenSapphire" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGreenSapphire" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneGreenSapphireOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneGreenSapphire" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGreenSapphire" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="GreenSapphireOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreGreenSapphire" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGreenSapphire" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteGreenSapphireOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteGreenSapphire" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGreenSapphire" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteGreenSapphireOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteGreenSapphire" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGreenSapphire" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackLazuriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackLazurite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLazurite" number="12" />
-        <itemStack oreDictionary="gemSodalite" chance="0.4" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneLazuriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneLazurite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLazurite" number="12" />
-        <itemStack oreDictionary="gemSodalite" chance="0.4" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="LazuriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreLazurite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLazurite" number="12" />
-        <itemStack oreDictionary="gemSodalite" chance="0.4" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteLazuriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteLazurite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLazurite" number="12" />
-        <itemStack oreDictionary="gemSodalite" chance="0.4" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteLazuriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteLazurite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLazurite" number="12" />
-        <itemStack oreDictionary="gemSodalite" chance="0.4" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackCassiteriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackCassiterite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCassiterite" number="4" />
-        <itemStack oreDictionary="dustTin" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneCassiteriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneCassiterite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCassiterite" number="4" />
-        <itemStack oreDictionary="dustTin" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="CassiteriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreCassiterite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCassiterite" number="4" />
-        <itemStack oreDictionary="dustTin" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteCassiteriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteCassiterite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCassiterite" number="4" />
-        <itemStack oreDictionary="dustTin" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteCassiteriteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteCassiterite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCassiterite" number="4" />
-        <itemStack oreDictionary="dustTin" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackTantaliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackTantalite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTantalite" number="2" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneTantaliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneTantalite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTantalite" number="2" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="TantaliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreTantalite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTantalite" number="2" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteTantaliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteTantalite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTantalite" number="2" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteTantaliteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteTantalite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTantalite" number="2" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackRubyOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackRuby" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRuby" number="2" />
-        <itemStack oreDictionary="dustChrome" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneRubyOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneRuby" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRuby" number="2" />
-        <itemStack oreDictionary="dustChrome" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RubyOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRuby" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRuby" number="2" />
-        <itemStack oreDictionary="dustChrome" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteRubyOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteRuby" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRuby" number="2" />
-        <itemStack oreDictionary="dustChrome" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteRubyOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteRuby" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRuby" number="2" />
-        <itemStack oreDictionary="dustChrome" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackPlatinumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackPlatinum" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPlatinum" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstonePlatinumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstonePlatinum" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPlatinum" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="PlatinumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="orePlatinum" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPlatinum" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgranitePlatinumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgranitePlatinum" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPlatinum" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgranitePlatinumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgranitePlatinum" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedPlatinum" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackGraphiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackGraphite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGraphite" number="2" />
-        <itemStack oreDictionary="dustCarbon" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneGraphiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneGraphite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGraphite" number="2" />
-        <itemStack oreDictionary="dustCarbon" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="GraphiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreGraphite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGraphite" number="2" />
-        <itemStack oreDictionary="dustCarbon" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteGraphiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteGraphite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGraphite" number="2" />
-        <itemStack oreDictionary="dustCarbon" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteGraphiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteGraphite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedGraphite" number="2" />
-        <itemStack oreDictionary="dustCarbon" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackMolybdeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackMolybdenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMolybdenite" number="2" />
-        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneMolybdeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneMolybdenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMolybdenite" number="2" />
-        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="MolybdeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreMolybdenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMolybdenite" number="2" />
-        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteMolybdeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteMolybdenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMolybdenite" number="2" />
-        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteMolybdeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteMolybdenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMolybdenite" number="2" />
-        <itemStack oreDictionary="dustMolybdenum" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackSpodumeneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackSpodumene" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSpodumene" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneSpodumeneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneSpodumene" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSpodumene" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="SpodumeneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreSpodumene" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSpodumene" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteSpodumeneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteSpodumene" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSpodumene" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteSpodumeneOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteSpodumene" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSpodumene" number="2" />
-        <itemStack oreDictionary="dustAluminium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackLithiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackLithium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLithium" number="2" />
-        <itemStack oreDictionary="dustLithium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneLithiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneLithium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLithium" number="2" />
-        <itemStack oreDictionary="dustLithium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="LithiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreLithium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLithium" number="2" />
-        <itemStack oreDictionary="dustLithium" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteLithiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteLithium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLithium" number="2" />
-        <itemStack oreDictionary="dustLithium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteLithiumOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteLithium" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedLithium" number="2" />
-        <itemStack oreDictionary="dustLithium" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackTungstateOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackTungstate" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTungstate" number="4" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneTungstateOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneTungstate" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTungstate" number="4" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="TungstateOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreTungstate" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTungstate" number="4" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteTungstateOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteTungstate" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTungstate" number="4" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteTungstateOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteTungstate" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedTungstate" number="4" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackWulfeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackWulfenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedWulfenite" number="2" />
-        <itemStack oreDictionary="dustWulfenite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneWulfeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneWulfenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedWulfenite" number="2" />
-        <itemStack oreDictionary="dustWulfenite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="WulfeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreWulfenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedWulfenite" number="2" />
-        <itemStack oreDictionary="dustWulfenite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteWulfeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteWulfenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedWulfenite" number="2" />
-        <itemStack oreDictionary="dustWulfenite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteWulfeniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteWulfenite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedWulfenite" number="2" />
-        <itemStack oreDictionary="dustWulfenite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPyrite" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="NetherrackGrossularOre" energyCost="32000">
@@ -3669,9 +334,10 @@ found in the core file.
         <itemStack oreDictionary="oreNetherrackGrossular" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedGrossular" number="2" />
-        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallGrossular" number="1" />
+        <itemStack oreDictionary="crushedGarnetYellow" number="1" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="EndstoneGrossularOre" energyCost="32000">
@@ -3679,9 +345,10 @@ found in the core file.
         <itemStack oreDictionary="oreEndstoneGrossular" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedGrossular" number="2" />
-        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallGrossular" number="1" />
+        <itemStack oreDictionary="crushedGarnetYellow" number="1" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="GrossularOre" energyCost="32000">
@@ -3689,9 +356,10 @@ found in the core file.
         <itemStack oreDictionary="oreGrossular" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedGrossular" number="2" />
-        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallGrossular" number="1" />
+        <itemStack oreDictionary="crushedGarnetYellow" number="1" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="RedgraniteGrossularOre" energyCost="32000">
@@ -3699,9 +367,10 @@ found in the core file.
         <itemStack oreDictionary="oreRedgraniteGrossular" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedGrossular" number="2" />
-        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallGrossular" number="1" />
+        <itemStack oreDictionary="crushedGarnetYellow" number="1" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="BlackgraniteGrossularOre" energyCost="32000">
@@ -3709,509 +378,65 @@ found in the core file.
         <itemStack oreDictionary="oreBlackgraniteGrossular" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedGrossular" number="2" />
-        <itemStack oreDictionary="gemGarnetYellow" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallGrossular" number="1" />
+        <itemStack oreDictionary="crushedGarnetYellow" number="1" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="NetherrackAmberOre" energyCost="32000">
+    <recipe name="NetherrackLepidoliteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreNetherrackAmber" />
+        <itemStack oreDictionary="oreNetherrackLepidolite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedAmber" number="4" />
-        <itemStack oreDictionary="gemAmber" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallLepidolite" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="EndstoneAmberOre" energyCost="32000">
+    <recipe name="EndstoneLepidoliteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreEndstoneAmber" />
+        <itemStack oreDictionary="oreEndstoneLepidolite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedAmber" number="4" />
-        <itemStack oreDictionary="gemAmber" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallLepidolite" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="AmberOre" energyCost="32000">
+    <recipe name="LepidoliteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreAmber" />
+        <itemStack oreDictionary="oreLepidolite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedAmber" number="4" />
-        <itemStack oreDictionary="gemAmber" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallLepidolite" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="RedgraniteAmberOre" energyCost="32000">
+    <recipe name="RedgraniteLepidoliteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreRedgraniteAmber" />
+        <itemStack oreDictionary="oreRedgraniteLepidolite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedAmber" number="4" />
-        <itemStack oreDictionary="gemAmber" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallLepidolite" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="BlackgraniteAmberOre" energyCost="32000">
+    <recipe name="BlackgraniteLepidoliteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreBlackgraniteAmber" />
+        <itemStack oreDictionary="oreBlackgraniteLepidolite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedAmber" number="4" />
-        <itemStack oreDictionary="gemAmber" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackRockSaltOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackRockSalt" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRockSalt" number="4" />
-        <itemStack oreDictionary="dustSalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneRockSaltOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneRockSalt" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRockSalt" number="4" />
-        <itemStack oreDictionary="dustSalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RockSaltOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRockSalt" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRockSalt" number="4" />
-        <itemStack oreDictionary="dustSalt" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteRockSaltOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteRockSalt" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRockSalt" number="4" />
-        <itemStack oreDictionary="dustSalt" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteRockSaltOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteRockSalt" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedRockSalt" number="4" />
-        <itemStack oreDictionary="dustSalt" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackMonaziteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackMonazite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMonazite" number="16" />
-        <itemStack oreDictionary="dustThorium" chance="0.2" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneMonaziteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneMonazite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMonazite" number="16" />
-        <itemStack oreDictionary="dustThorium" chance="0.2" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="MonaziteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreMonazite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMonazite" number="16" />
-        <itemStack oreDictionary="dustThorium" chance="0.2" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteMonaziteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteMonazite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMonazite" number="16" />
-        <itemStack oreDictionary="dustThorium" chance="0.2" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteMonaziteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteMonazite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedMonazite" number="16" />
-        <itemStack oreDictionary="dustThorium" chance="0.2" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackVanadiumMagnetiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackVanadiumMagnetite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedVanadiumMagnetite" number="2" />
-        <itemStack oreDictionary="dustMagnetite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneVanadiumMagnetiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneVanadiumMagnetite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedVanadiumMagnetite" number="2" />
-        <itemStack oreDictionary="dustMagnetite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="VanadiumMagnetiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreVanadiumMagnetite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedVanadiumMagnetite" number="2" />
-        <itemStack oreDictionary="dustMagnetite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteVanadiumMagnetiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteVanadiumMagnetite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedVanadiumMagnetite" number="2" />
-        <itemStack oreDictionary="dustMagnetite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteVanadiumMagnetiteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteVanadiumMagnetite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedVanadiumMagnetite" number="2" />
-        <itemStack oreDictionary="dustMagnetite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackCoalOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackCoal" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCoal" number="2" />
-        <itemStack oreDictionary="gemLignite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneCoalOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneCoal" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCoal" number="2" />
-        <itemStack oreDictionary="gemLignite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="CoalOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreCoal" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCoal" number="2" />
-        <itemStack oreDictionary="gemLignite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteCoalOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteCoal" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCoal" number="2" />
-        <itemStack oreDictionary="gemLignite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteCoalOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteCoal" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedCoal" number="2" />
-        <itemStack oreDictionary="gemLignite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackSiliconOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackSilicon" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSilicon" number="2" />
-        <itemStack oreDictionary="dustSiliconDioxide" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneSiliconOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneSilicon" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSilicon" number="2" />
-        <itemStack oreDictionary="dustSiliconDioxide" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="SiliconOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreSilicon" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSilicon" number="2" />
-        <itemStack oreDictionary="dustSiliconDioxide" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteSiliconOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteSilicon" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSilicon" number="2" />
-        <itemStack oreDictionary="dustSiliconDioxide" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteSiliconOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteSilicon" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedSilicon" number="2" />
-        <itemStack oreDictionary="dustSiliconDioxide" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackNaquadahOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackNaquadah" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNaquadah" number="2" />
-        <itemStack oreDictionary="dustNaquadahEnriched" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneNaquadahOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneNaquadah" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNaquadah" number="2" />
-        <itemStack oreDictionary="dustNaquadahEnriched" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NaquadahOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNaquadah" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNaquadah" number="2" />
-        <itemStack oreDictionary="dustNaquadahEnriched" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteNaquadahOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteNaquadah" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNaquadah" number="2" />
-        <itemStack oreDictionary="dustNaquadahEnriched" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteNaquadahOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteNaquadah" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedNaquadah" number="2" />
-        <itemStack oreDictionary="dustNaquadahEnriched" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackIronOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackIron" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIron" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneIronOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneIron" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIron" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="IronOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreIron" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIron" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteIronOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteIron" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIron" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteIronOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteIron" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedIron" number="2" />
-        <itemStack oreDictionary="dustNickel" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackStibniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackStibnite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedStibnite" number="2" />
-        <itemStack oreDictionary="dustAntimony" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneStibniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneStibnite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedStibnite" number="2" />
-        <itemStack oreDictionary="dustAntimony" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="StibniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreStibnite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedStibnite" number="2" />
-        <itemStack oreDictionary="dustAntimony" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteStibniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteStibnite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedStibnite" number="2" />
-        <itemStack oreDictionary="dustAntimony" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteStibniteOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteStibnite" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedStibnite" number="2" />
-        <itemStack oreDictionary="dustAntimony" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="NetherrackBandedIronOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreNetherrackBandedIron" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBandedIron" number="2" />
-        <itemStack oreDictionary="dustBandedIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="EndstoneBandedIronOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreEndstoneBandedIron" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBandedIron" number="2" />
-        <itemStack oreDictionary="dustBandedIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BandedIronOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBandedIron" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBandedIron" number="2" />
-        <itemStack oreDictionary="dustBandedIron" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="RedgraniteBandedIronOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreRedgraniteBandedIron" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBandedIron" number="2" />
-        <itemStack oreDictionary="dustBandedIron" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
-      </output>
-    </recipe>
-    <recipe name="BlackgraniteBandedIronOre" energyCost="32000">
-      <input>
-        <itemStack oreDictionary="oreBlackgraniteBandedIron" />
-      </input>
-      <output>
-        <itemStack oreDictionary="crushedBandedIron" number="2" />
-        <itemStack oreDictionary="dustBandedIron" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallLepidolite" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="NetherrackPhosphorusOre" energyCost="32000">
@@ -4219,9 +444,10 @@ found in the core file.
         <itemStack oreDictionary="oreNetherrackPhosphorus" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPhosphorus" number="6" />
-        <itemStack oreDictionary="gemApatite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPhosphorus" number="3" />
+        <itemStack oreDictionary="crushedApatite" number="1" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="EndstonePhosphorusOre" energyCost="32000">
@@ -4229,9 +455,10 @@ found in the core file.
         <itemStack oreDictionary="oreEndstonePhosphorus" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPhosphorus" number="6" />
-        <itemStack oreDictionary="gemApatite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPhosphorus" number="3" />
+        <itemStack oreDictionary="crushedApatite" number="1" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="PhosphorusOre" energyCost="32000">
@@ -4239,9 +466,10 @@ found in the core file.
         <itemStack oreDictionary="orePhosphorus" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPhosphorus" number="6" />
-        <itemStack oreDictionary="gemApatite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPhosphorus" number="3" />
+        <itemStack oreDictionary="crushedApatite" number="1" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="RedgranitePhosphorusOre" energyCost="32000">
@@ -4249,9 +477,10 @@ found in the core file.
         <itemStack oreDictionary="oreRedgranitePhosphorus" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPhosphorus" number="6" />
-        <itemStack oreDictionary="gemApatite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPhosphorus" number="3" />
+        <itemStack oreDictionary="crushedApatite" number="1" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="BlackgranitePhosphorusOre" energyCost="32000">
@@ -4259,209 +488,340 @@ found in the core file.
         <itemStack oreDictionary="oreBlackgranitePhosphorus" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPhosphorus" number="6" />
-        <itemStack oreDictionary="gemApatite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPhosphorus" number="3" />
+        <itemStack oreDictionary="crushedApatite" number="1" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="NetherrackCalciteOre" energyCost="32000">
+    <recipe name="NetherrackSulfurOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreNetherrackCalcite" />
+        <itemStack oreDictionary="oreNetherrackSulfur" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedCalcite" number="2" />
-        <itemStack oreDictionary="dustAndradite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallSulfur" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="EndstoneCalciteOre" energyCost="32000">
+    <recipe name="EndstoneSulfurOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreEndstoneCalcite" />
+        <itemStack oreDictionary="oreEndstoneSulfur" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedCalcite" number="2" />
-        <itemStack oreDictionary="dustAndradite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallSulfur" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="CalciteOre" energyCost="32000">
+    <recipe name="SulfurOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreCalcite" />
+        <itemStack oreDictionary="oreSulfur" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedCalcite" number="2" />
-        <itemStack oreDictionary="dustAndradite" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallSulfur" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="RedgraniteCalciteOre" energyCost="32000">
+    <recipe name="RedgraniteSulfurOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreRedgraniteCalcite" />
+        <itemStack oreDictionary="oreRedgraniteSulfur" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedCalcite" number="2" />
-        <itemStack oreDictionary="dustAndradite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallSulfur" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="BlackgraniteCalciteOre" energyCost="32000">
+    <recipe name="BlackgraniteSulfurOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreBlackgraniteCalcite" />
+        <itemStack oreDictionary="oreBlackgraniteSulfur" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedCalcite" number="2" />
-        <itemStack oreDictionary="dustAndradite" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallSulfur" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="NetherrackGoldOre" energyCost="32000">
+    <recipe name="NetherrackBariteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreNetherrackGold" />
+        <itemStack oreDictionary="oreNetherrackBarite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedGold" number="2" />
-        <itemStack oreDictionary="dustCopper" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallBarite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="EndstoneGoldOre" energyCost="32000">
+    <recipe name="EndstoneBariteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreEndstoneGold" />
+        <itemStack oreDictionary="oreEndstoneBarite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedGold" number="2" />
-        <itemStack oreDictionary="dustCopper" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallBarite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="GoldOre" energyCost="32000">
+    <recipe name="BariteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreGold" />
+        <itemStack oreDictionary="oreBarite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedGold" number="2" />
-        <itemStack oreDictionary="dustCopper" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallBarite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="RedgraniteGoldOre" energyCost="32000">
+    <recipe name="RedgraniteBariteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreRedgraniteGold" />
+        <itemStack oreDictionary="oreRedgraniteBarite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedGold" number="2" />
-        <itemStack oreDictionary="dustCopper" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallBarite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="BlackgraniteGoldOre" energyCost="32000">
+    <recipe name="BlackgraniteBariteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreBlackgraniteGold" />
+        <itemStack oreDictionary="oreBlackgraniteBarite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedGold" number="2" />
-        <itemStack oreDictionary="dustCopper" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallBarite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="NetherrackMalachiteOre" energyCost="32000">
+    <recipe name="NetherrackPentlanditeOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreNetherrackMalachite" />
+        <itemStack oreDictionary="oreNetherrackPentlandite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedMalachite" number="2" />
-        <itemStack oreDictionary="dustCopper" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPentlandite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="EndstoneMalachiteOre" energyCost="32000">
+    <recipe name="EndstonePentlanditeOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreEndstoneMalachite" />
+        <itemStack oreDictionary="oreEndstonePentlandite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedMalachite" number="2" />
-        <itemStack oreDictionary="dustCopper" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPentlandite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="MalachiteOre" energyCost="32000">
+    <recipe name="PentlanditeOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreMalachite" />
+        <itemStack oreDictionary="orePentlandite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedMalachite" number="2" />
-        <itemStack oreDictionary="dustCopper" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPentlandite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="RedgraniteMalachiteOre" energyCost="32000">
+    <recipe name="RedgranitePentlanditeOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreRedgraniteMalachite" />
+        <itemStack oreDictionary="oreRedgranitePentlandite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedMalachite" number="2" />
-        <itemStack oreDictionary="dustCopper" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPentlandite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="BlackgraniteMalachiteOre" energyCost="32000">
+    <recipe name="BlackgranitePentlanditeOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreBlackgraniteMalachite" />
+        <itemStack oreDictionary="oreBlackgranitePentlandite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedMalachite" number="2" />
-        <itemStack oreDictionary="dustCopper" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallPentlandite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="NetherrackPyrolusiteOre" energyCost="32000">
+    <recipe name="NetherrackTantaliteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreNetherrackPyrolusite" />
+        <itemStack oreDictionary="oreNetherrackTantalite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPyrolusite" number="2" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallTantalite" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="EndstonePyrolusiteOre" energyCost="32000">
+    <recipe name="EndstoneTantaliteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreEndstonePyrolusite" />
+        <itemStack oreDictionary="oreEndstoneTantalite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPyrolusite" number="2" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallTantalite" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="PyrolusiteOre" energyCost="32000">
+    <recipe name="TantaliteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="orePyrolusite" />
+        <itemStack oreDictionary="oreTantalite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPyrolusite" number="2" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallTantalite" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="RedgranitePyrolusiteOre" energyCost="32000">
+    <recipe name="RedgraniteTantaliteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreRedgranitePyrolusite" />
+        <itemStack oreDictionary="oreRedgraniteTantalite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPyrolusite" number="2" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallTantalite" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.1" />
       </output>
     </recipe>
-    <recipe name="BlackgranitePyrolusiteOre" energyCost="32000">
+    <recipe name="BlackgraniteTantaliteOre" energyCost="32000">
       <input>
-        <itemStack oreDictionary="oreBlackgranitePyrolusite" />
+        <itemStack oreDictionary="oreBlackgraniteTantalite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedPyrolusite" number="2" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallTantalite" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackQuartziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackQuartzite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallQuartzite" number="1" />
+        <itemStack oreDictionary="crushedCertusQuartz" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneQuartziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneQuartzite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallQuartzite" number="1" />
+        <itemStack oreDictionary="crushedCertusQuartz" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="QuartziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreQuartzite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallQuartzite" number="1" />
+        <itemStack oreDictionary="crushedCertusQuartz" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteQuartziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteQuartzite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallQuartzite" number="1" />
+        <itemStack oreDictionary="crushedCertusQuartz" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteQuartziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteQuartzite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallQuartzite" number="1" />
+        <itemStack oreDictionary="crushedCertusQuartz" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCoalOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCoal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCoal" number="1" />
+        <itemStack oreDictionary="crushedLignite" number="1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCoalOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCoal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCoal" number="1" />
+        <itemStack oreDictionary="crushedLignite" number="1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="CoalOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCoal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCoal" number="1" />
+        <itemStack oreDictionary="crushedLignite" number="1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCoalOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCoal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCoal" number="1" />
+        <itemStack oreDictionary="crushedLignite" number="1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCoalOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCoal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCoal" number="1" />
+        <itemStack oreDictionary="crushedLignite" number="1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="NetherrackScheeliteOre" energyCost="32000">
@@ -4469,9 +829,10 @@ found in the core file.
         <itemStack oreDictionary="oreNetherrackScheelite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedScheelite" number="4" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="netherrack" chance="0.5" />
+        <itemStack oreDictionary="dustSmallScheelite" number="2" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="EndstoneScheeliteOre" energyCost="32000">
@@ -4479,9 +840,10 @@ found in the core file.
         <itemStack oreDictionary="oreEndstoneScheelite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedScheelite" number="4" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="end_stone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallScheelite" number="2" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="ScheeliteOre" energyCost="32000">
@@ -4489,9 +851,10 @@ found in the core file.
         <itemStack oreDictionary="oreScheelite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedScheelite" number="4" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="minecraft" itemName="cobblestone" chance="0.5" />
+        <itemStack oreDictionary="dustSmallScheelite" number="2" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="RedgraniteScheeliteOre" energyCost="32000">
@@ -4499,9 +862,10 @@ found in the core file.
         <itemStack oreDictionary="oreRedgraniteScheelite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedScheelite" number="4" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="9" chance="0.5" />
+        <itemStack oreDictionary="dustSmallScheelite" number="2" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
       </output>
     </recipe>
     <recipe name="BlackgraniteScheeliteOre" energyCost="32000">
@@ -4509,13 +873,4082 @@ found in the core file.
         <itemStack oreDictionary="oreBlackgraniteScheelite" />
       </input>
       <output>
-        <itemStack oreDictionary="crushedScheelite" number="4" />
-        <itemStack oreDictionary="dustManganese" chance="0.1" />
-        <itemStack modID="gregtech" itemName="gt.blockgranites" itemMeta="1" chance="0.5" />
+        <itemStack oreDictionary="dustSmallScheelite" number="2" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSilverOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSilver" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSilverOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSilver" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="SilverOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSilver" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSilverOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSilver" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSilverOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSilver" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLeadOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLead" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLeadOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLead" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="LeadOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLead" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteLeadOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLead" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteLeadOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLead" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSpodumeneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSpodumene" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSpodumene" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSpodumeneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSpodumene" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSpodumene" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="SpodumeneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSpodumene" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSpodumene" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSpodumeneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSpodumene" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSpodumene" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSpodumeneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSpodumene" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSpodumene" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBrownLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBrownLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBrownLimonite" number="1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBrownLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBrownLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBrownLimonite" number="1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BrownLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBrownLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBrownLimonite" number="1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBrownLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBrownLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBrownLimonite" number="1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBrownLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBrownLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBrownLimonite" number="1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLigniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLignite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLignite" number="1" />
+        <itemStack oreDictionary="crushedCoal" number="1" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLigniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLignite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLignite" number="1" />
+        <itemStack oreDictionary="crushedCoal" number="1" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="LigniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreLignite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLignite" number="1" />
+        <itemStack oreDictionary="crushedCoal" number="1" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteLigniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteLignite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLignite" number="1" />
+        <itemStack oreDictionary="crushedCoal" number="1" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteLigniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteLignite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLignite" number="1" />
+        <itemStack oreDictionary="crushedCoal" number="1" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPhosphateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPhosphate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPhosphate" number="1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePhosphateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePhosphate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPhosphate" number="1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="PhosphateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePhosphate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPhosphate" number="1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePhosphateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePhosphate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPhosphate" number="1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePhosphateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePhosphate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPhosphate" number="1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackDiamondOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackDiamond" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallDiamond" number="1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneDiamondOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneDiamond" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallDiamond" number="1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="DiamondOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreDiamond" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallDiamond" number="1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteDiamondOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteDiamond" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallDiamond" number="1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteDiamondOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteDiamond" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallDiamond" number="1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPlatinumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPlatinum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPlatinum" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePlatinumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePlatinum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPlatinum" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="PlatinumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePlatinum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPlatinum" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePlatinumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePlatinum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPlatinum" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePlatinumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePlatinum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPlatinum" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackYellowLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackYellowLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallYellowLimonite" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneYellowLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneYellowLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallYellowLimonite" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="YellowLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreYellowLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallYellowLimonite" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteYellowLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteYellowLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallYellowLimonite" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteYellowLimoniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteYellowLimonite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallYellowLimonite" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCobaltiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCobaltite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCobaltite" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCobaltiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCobaltite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCobaltite" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="CobaltiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCobaltite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCobaltite" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCobaltiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCobaltite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCobaltite" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCobaltiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCobaltite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCobaltite" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLapisOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLapis" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLapis" number="6" />
+        <itemStack oreDictionary="crushedLazurite" number="4" />
+        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLapisOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLapis" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLapis" number="6" />
+        <itemStack oreDictionary="crushedLazurite" number="4" />
+        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="LapisOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreLapis" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLapis" number="6" />
+        <itemStack oreDictionary="crushedLazurite" number="4" />
+        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteLapisOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteLapis" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLapis" number="6" />
+        <itemStack oreDictionary="crushedLazurite" number="4" />
+        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteLapisOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteLapis" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLapis" number="6" />
+        <itemStack oreDictionary="crushedLazurite" number="4" />
+        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackVanadiumMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackVanadiumMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallVanadiumMagnetite" number="1" />
+        <itemStack oreDictionary="crushedMagnetite" number="1" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneVanadiumMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneVanadiumMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallVanadiumMagnetite" number="1" />
+        <itemStack oreDictionary="crushedMagnetite" number="1" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="VanadiumMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreVanadiumMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallVanadiumMagnetite" number="1" />
+        <itemStack oreDictionary="crushedMagnetite" number="1" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteVanadiumMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteVanadiumMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallVanadiumMagnetite" number="1" />
+        <itemStack oreDictionary="crushedMagnetite" number="1" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteVanadiumMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteVanadiumMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallVanadiumMagnetite" number="1" />
+        <itemStack oreDictionary="crushedMagnetite" number="1" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSalt" number="2" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSalt" number="2" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="SaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSalt" number="2" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSalt" number="2" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSalt" number="2" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCassiteriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCassiterite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCassiterite" number="2" />
+        <itemStack oreDictionary="crushedTin" number="1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCassiteriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCassiterite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCassiterite" number="2" />
+        <itemStack oreDictionary="crushedTin" number="1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="CassiteriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCassiterite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCassiterite" number="2" />
+        <itemStack oreDictionary="crushedTin" number="1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCassiteriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCassiterite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCassiterite" number="2" />
+        <itemStack oreDictionary="crushedTin" number="1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCassiteriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCassiterite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCassiterite" number="2" />
+        <itemStack oreDictionary="crushedTin" number="1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackNickelOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNickel" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneNickelOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNickel" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NickelOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNickel" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteNickelOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNickel" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteNickelOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNickel" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMalachiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMalachite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMalachite" number="1" />
+        <itemStack oreDictionary="crushedCopper" number="1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMalachiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMalachite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMalachite" number="1" />
+        <itemStack oreDictionary="crushedCopper" number="1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="MalachiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMalachite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMalachite" number="1" />
+        <itemStack oreDictionary="crushedCopper" number="1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMalachiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMalachite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMalachite" number="1" />
+        <itemStack oreDictionary="crushedCopper" number="1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMalachiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMalachite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMalachite" number="1" />
+        <itemStack oreDictionary="crushedCopper" number="1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIron" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIron" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="IronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIron" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIron" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIron" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackRockSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackRockSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRockSalt" number="2" />
+        <itemStack oreDictionary="crushedSalt" number="1" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneRockSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneRockSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRockSalt" number="2" />
+        <itemStack oreDictionary="crushedSalt" number="1" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RockSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRockSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRockSalt" number="2" />
+        <itemStack oreDictionary="crushedSalt" number="1" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteRockSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteRockSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRockSalt" number="2" />
+        <itemStack oreDictionary="crushedSalt" number="1" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteRockSaltOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteRockSalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRockSalt" number="2" />
+        <itemStack oreDictionary="crushedSalt" number="1" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPalladiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPalladium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPalladium" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePalladiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePalladium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPalladium" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="PalladiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePalladium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPalladium" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePalladiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePalladium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPalladium" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePalladiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePalladium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPalladium" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCheeseOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCheese" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCheese" number="1" />
+        <itemStack oreDictionary="crushedCheese" number="1" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCheeseOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCheese" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCheese" number="1" />
+        <itemStack oreDictionary="crushedCheese" number="1" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="CheeseOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCheese" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCheese" number="1" />
+        <itemStack oreDictionary="crushedCheese" number="1" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCheeseOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCheese" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCheese" number="1" />
+        <itemStack oreDictionary="crushedCheese" number="1" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCheeseOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCheese" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCheese" number="1" />
+        <itemStack oreDictionary="crushedCheese" number="1" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackTungstateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackTungstate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTungstate" number="2" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneTungstateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneTungstate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTungstate" number="2" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="TungstateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreTungstate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTungstate" number="2" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteTungstateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteTungstate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTungstate" number="2" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteTungstateOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteTungstate" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTungstate" number="2" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBerylliumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBeryllium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBeryllium" number="1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBerylliumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBeryllium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBeryllium" number="1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BerylliumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBeryllium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBeryllium" number="1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBerylliumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBeryllium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBeryllium" number="1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBerylliumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBeryllium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBeryllium" number="1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBauxiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBauxite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBauxite" number="1" />
+        <itemStack oreDictionary="crushedGrossular" number="1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGallium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBauxiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBauxite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBauxite" number="1" />
+        <itemStack oreDictionary="crushedGrossular" number="1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGallium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BauxiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBauxite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBauxite" number="1" />
+        <itemStack oreDictionary="crushedGrossular" number="1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGallium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBauxiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBauxite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBauxite" number="1" />
+        <itemStack oreDictionary="crushedGrossular" number="1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGallium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBauxiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBauxite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBauxite" number="1" />
+        <itemStack oreDictionary="crushedGrossular" number="1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGallium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCalciteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCalcite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCalcite" number="1" />
+        <itemStack oreDictionary="crushedAndradite" number="1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCalciteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCalcite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCalcite" number="1" />
+        <itemStack oreDictionary="crushedAndradite" number="1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="CalciteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCalcite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCalcite" number="1" />
+        <itemStack oreDictionary="crushedAndradite" number="1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCalciteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCalcite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCalcite" number="1" />
+        <itemStack oreDictionary="crushedAndradite" number="1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCalciteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCalcite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCalcite" number="1" />
+        <itemStack oreDictionary="crushedAndradite" number="1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackNaquadahOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackNaquadah" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNaquadah" number="1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneNaquadahOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneNaquadah" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNaquadah" number="1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NaquadahOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNaquadah" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNaquadah" number="1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteNaquadahOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteNaquadah" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNaquadah" number="1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteNaquadahOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteNaquadah" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNaquadah" number="1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSphaleriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSphalerite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSphalerite" number="1" />
+        <itemStack oreDictionary="crushedGarnetYellow" number="1" />
+        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSphaleriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSphalerite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSphalerite" number="1" />
+        <itemStack oreDictionary="crushedGarnetYellow" number="1" />
+        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="SphaleriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSphalerite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSphalerite" number="1" />
+        <itemStack oreDictionary="crushedGarnetYellow" number="1" />
+        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSphaleriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSphalerite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSphalerite" number="1" />
+        <itemStack oreDictionary="crushedGarnetYellow" number="1" />
+        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSphaleriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSphalerite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSphalerite" number="1" />
+        <itemStack oreDictionary="crushedGarnetYellow" number="1" />
+        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCooperiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCooperite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCooperite" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCooperiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCooperite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCooperite" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="CooperiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCooperite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCooperite" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCooperiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCooperite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCooperite" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCooperiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCooperite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCooperite" number="1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackNeodymiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackNeodymium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNeodymium" number="1" />
+        <itemStack oreDictionary="crushedMonazite" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneNeodymiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneNeodymium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNeodymium" number="1" />
+        <itemStack oreDictionary="crushedMonazite" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NeodymiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNeodymium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNeodymium" number="1" />
+        <itemStack oreDictionary="crushedMonazite" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteNeodymiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteNeodymium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNeodymium" number="1" />
+        <itemStack oreDictionary="crushedMonazite" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteNeodymiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteNeodymium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNeodymium" number="1" />
+        <itemStack oreDictionary="crushedMonazite" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackApatiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackApatite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallApatite" number="4" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneApatiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneApatite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallApatite" number="4" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="ApatiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreApatite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallApatite" number="4" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteApatiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteApatite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallApatite" number="4" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteApatiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteApatite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallApatite" number="4" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.33" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackAluminiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAluminium" number="1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneAluminiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAluminium" number="1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="AluminiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAluminium" number="1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteAluminiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAluminium" number="1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteAluminiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAluminium" number="1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackAmberOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackAmber" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAmber" number="2" />
+        <itemStack oreDictionary="crushedAmber" number="1" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneAmberOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneAmber" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAmber" number="2" />
+        <itemStack oreDictionary="crushedAmber" number="1" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="AmberOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreAmber" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAmber" number="2" />
+        <itemStack oreDictionary="crushedAmber" number="1" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteAmberOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteAmber" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAmber" number="2" />
+        <itemStack oreDictionary="crushedAmber" number="1" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteAmberOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteAmber" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAmber" number="2" />
+        <itemStack oreDictionary="crushedAmber" number="1" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackUraniniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackUraninite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallUraninite" number="1" />
+        <itemStack oreDictionary="crushedUranium" number="1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneUraniniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneUraninite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallUraninite" number="1" />
+        <itemStack oreDictionary="crushedUranium" number="1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="UraniniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreUraninite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallUraninite" number="1" />
+        <itemStack oreDictionary="crushedUranium" number="1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteUraniniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteUraninite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallUraninite" number="1" />
+        <itemStack oreDictionary="crushedUranium" number="1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteUraniniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteUraninite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallUraninite" number="1" />
+        <itemStack oreDictionary="crushedUranium" number="1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGalenaOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGalena" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGalena" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGalenaOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGalena" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGalena" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="GalenaOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGalena" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGalena" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGalenaOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGalena" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGalena" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGalenaOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGalena" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGalena" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackNetherQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackNetherQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNetherQuartz" number="2" />
+        <itemStack oreDictionary="dustNetherrack" number="1" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneNetherQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneNetherQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNetherQuartz" number="2" />
+        <itemStack oreDictionary="dustNetherrack" number="1" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNetherQuartz" number="2" />
+        <itemStack oreDictionary="dustNetherrack" number="1" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteNetherQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteNetherQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNetherQuartz" number="2" />
+        <itemStack oreDictionary="dustNetherrack" number="1" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteNetherQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteNetherQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallNetherQuartz" number="2" />
+        <itemStack oreDictionary="dustNetherrack" number="1" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackRubyOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackRuby" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRuby" number="1" />
+        <itemStack oreDictionary="crushedChrome" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneRubyOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneRuby" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRuby" number="1" />
+        <itemStack oreDictionary="crushedChrome" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RubyOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRuby" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRuby" number="1" />
+        <itemStack oreDictionary="crushedChrome" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteRubyOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteRuby" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRuby" number="1" />
+        <itemStack oreDictionary="crushedChrome" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteRubyOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteRuby" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRuby" number="1" />
+        <itemStack oreDictionary="crushedChrome" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGarnieriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGarnierite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGarnierite" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGarnieriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGarnierite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGarnierite" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="GarnieriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGarnierite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGarnierite" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGarnieriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGarnierite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGarnierite" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGarnieriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGarnierite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGarnierite" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackIlmeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackIlmenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIlmenite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneIlmeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneIlmenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIlmenite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="IlmeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreIlmenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIlmenite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteIlmeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteIlmenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIlmenite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteIlmeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteIlmenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIlmenite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackDeshOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackDesh" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallDesh" number="1" />
+        <itemStack oreDictionary="crushedDesh" number="1" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneDeshOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneDesh" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallDesh" number="1" />
+        <itemStack oreDictionary="crushedDesh" number="1" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="DeshOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreDesh" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallDesh" number="1" />
+        <itemStack oreDictionary="crushedDesh" number="1" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteDeshOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteDesh" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallDesh" number="1" />
+        <itemStack oreDictionary="crushedDesh" number="1" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteDeshOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteDesh" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallDesh" number="1" />
+        <itemStack oreDictionary="crushedDesh" number="1" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCertusQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCertusQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCertusQuartz" number="2" />
+        <itemStack oreDictionary="crushedQuartzite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCertusQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCertusQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCertusQuartz" number="2" />
+        <itemStack oreDictionary="crushedQuartzite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="CertusQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCertusQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCertusQuartz" number="2" />
+        <itemStack oreDictionary="crushedQuartzite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCertusQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCertusQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCertusQuartz" number="2" />
+        <itemStack oreDictionary="crushedQuartzite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCertusQuartzOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCertusQuartz" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCertusQuartz" number="2" />
+        <itemStack oreDictionary="crushedQuartzite" number="1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMolybdeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMolybdenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMolybdenite" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMolybdeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMolybdenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMolybdenite" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="MolybdeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMolybdenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMolybdenite" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMolybdeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMolybdenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMolybdenite" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMolybdeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMolybdenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMolybdenite" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackFirestoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackFirestone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallFirestone" number="1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneFirestoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneFirestone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallFirestone" number="1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="FirestoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreFirestone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallFirestone" number="1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteFirestoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteFirestone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallFirestone" number="1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteFirestoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteFirestone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallFirestone" number="1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSapphire" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSapphire" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="SapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSapphire" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSapphire" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSapphire" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPyropeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPyrope" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPyrope" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePyropeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePyrope" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPyrope" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="PyropeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePyrope" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPyrope" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePyropeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePyrope" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPyrope" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePyropeOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePyrope" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPyrope" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackWulfeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackWulfenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallWulfenite" number="1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneWulfeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneWulfenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallWulfenite" number="1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="WulfeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreWulfenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallWulfenite" number="1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteWulfeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteWulfenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallWulfenite" number="1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteWulfeniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteWulfenite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallWulfenite" number="1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPowelliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPowellite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPowellite" number="1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePowelliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePowellite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPowellite" number="1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="PowelliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePowellite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPowellite" number="1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePowelliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePowellite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPowellite" number="1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePowelliteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePowellite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPowellite" number="1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGraphiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGraphite" number="1" />
+        <itemStack oreDictionary="dustCarbon" number="1" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGraphiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGraphite" number="1" />
+        <itemStack oreDictionary="dustCarbon" number="1" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="GraphiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGraphite" number="1" />
+        <itemStack oreDictionary="dustCarbon" number="1" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGraphiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGraphite" number="1" />
+        <itemStack oreDictionary="dustCarbon" number="1" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGraphiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGraphite" number="1" />
+        <itemStack oreDictionary="dustCarbon" number="1" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGreenSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGreenSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGreenSapphire" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGreenSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGreenSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGreenSapphire" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="GreenSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGreenSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGreenSapphire" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGreenSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGreenSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGreenSapphire" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGreenSapphireOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGreenSapphire" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGreenSapphire" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMagnesiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMagnesite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMagnesite" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMagnesiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMagnesite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMagnesite" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="MagnesiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMagnesite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMagnesite" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMagnesiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMagnesite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMagnesite" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMagnesiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMagnesite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMagnesite" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCopperOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCopper" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCopperOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCopper" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="CopperOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCopper" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCopperOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCopper" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCopperOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCopper" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLithiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLithium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLithium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLithiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLithium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLithium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="LithiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreLithium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLithium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteLithiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteLithium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLithium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteLithiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteLithium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLithium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackRedstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackRedstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRedstone" number="5" />
+        <itemStack oreDictionary="crushedCinnabar" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneRedstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneRedstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRedstone" number="5" />
+        <itemStack oreDictionary="crushedCinnabar" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRedstone" number="5" />
+        <itemStack oreDictionary="crushedCinnabar" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteRedstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteRedstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRedstone" number="5" />
+        <itemStack oreDictionary="crushedCinnabar" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteRedstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteRedstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallRedstone" number="5" />
+        <itemStack oreDictionary="crushedCinnabar" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBandedIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBandedIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBandedIron" number="1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBandedIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBandedIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBandedIron" number="1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BandedIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBandedIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBandedIron" number="1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBandedIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBandedIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBandedIron" number="1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBandedIronOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBandedIron" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBandedIron" number="1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackCinnabarOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackCinnabar" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCinnabar" number="1" />
+        <itemStack oreDictionary="crushedRedstone" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneCinnabarOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneCinnabar" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCinnabar" number="1" />
+        <itemStack oreDictionary="crushedRedstone" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="CinnabarOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreCinnabar" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCinnabar" number="1" />
+        <itemStack oreDictionary="crushedRedstone" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteCinnabarOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteCinnabar" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCinnabar" number="1" />
+        <itemStack oreDictionary="crushedRedstone" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteCinnabarOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteCinnabar" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallCinnabar" number="1" />
+        <itemStack oreDictionary="crushedRedstone" number="1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackUraniumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackUranium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallUranium" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneUraniumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneUranium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallUranium" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="UraniumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreUranium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallUranium" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteUraniumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteUranium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallUranium" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteUraniumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteUranium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallUranium" number="1" />
+        <itemStack oreDictionary="crushedLead" number="1" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGlauconiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGlauconite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGlauconite" number="1" />
+        <itemStack oreDictionary="crushedSodium" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGlauconiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGlauconite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGlauconite" number="1" />
+        <itemStack oreDictionary="crushedSodium" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="GlauconiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGlauconite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGlauconite" number="1" />
+        <itemStack oreDictionary="crushedSodium" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGlauconiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGlauconite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGlauconite" number="1" />
+        <itemStack oreDictionary="crushedSodium" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGlauconiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGlauconite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGlauconite" number="1" />
+        <itemStack oreDictionary="crushedSodium" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSaltpeterOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSaltpeter" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSaltpeter" number="4" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSaltpeterOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSaltpeter" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSaltpeter" number="4" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="SaltpeterOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSaltpeter" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSaltpeter" number="4" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSaltpeterOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSaltpeter" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSaltpeter" number="4" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSaltpeterOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSaltpeter" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSaltpeter" number="4" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackTinOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTin" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneTinOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTin" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="TinOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTin" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteTinOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTin" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteTinOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTin" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMagnetite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMagnetite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="MagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMagnetite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMagnetite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMagnetiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMagnetite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMagnetite" number="1" />
+        <itemStack oreDictionary="crushedIron" number="1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSiliconOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSilicon" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSilicon" number="1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSiliconOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSilicon" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSilicon" number="1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="SiliconOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSilicon" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSilicon" number="1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSiliconOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSilicon" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSilicon" number="1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSiliconOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSilicon" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSilicon" number="1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSpessartineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSpessartine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSpessartine" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSpessartineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSpessartine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSpessartine" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="SpessartineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSpessartine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSpessartine" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSpessartineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSpessartine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSpessartine" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSpessartineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSpessartine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSpessartine" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackBastnasiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackBastnasite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBastnasite" number="1" />
+        <itemStack oreDictionary="crushedNeodymium" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneBastnasiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneBastnasite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBastnasite" number="1" />
+        <itemStack oreDictionary="crushedNeodymium" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BastnasiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBastnasite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBastnasite" number="1" />
+        <itemStack oreDictionary="crushedNeodymium" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteBastnasiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteBastnasite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBastnasite" number="1" />
+        <itemStack oreDictionary="crushedNeodymium" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteBastnasiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteBastnasite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallBastnasite" number="1" />
+        <itemStack oreDictionary="crushedNeodymium" number="1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackGoldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackGold" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGold" number="1" />
+        <itemStack oreDictionary="crushedCopper" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneGoldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneGold" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGold" number="1" />
+        <itemStack oreDictionary="crushedCopper" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="GoldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreGold" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGold" number="1" />
+        <itemStack oreDictionary="crushedCopper" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteGoldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteGold" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGold" number="1" />
+        <itemStack oreDictionary="crushedCopper" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteGoldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteGold" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallGold" number="1" />
+        <itemStack oreDictionary="crushedCopper" number="1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackSoapstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackSoapstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSoapstone" number="1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneSoapstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneSoapstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSoapstone" number="1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="SoapstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreSoapstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSoapstone" number="1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteSoapstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteSoapstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSoapstone" number="1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteSoapstoneOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteSoapstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallSoapstone" number="1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackLazuriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackLazurite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLazurite" number="6" />
+        <itemStack oreDictionary="crushedSodalite" number="4" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneLazuriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneLazurite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLazurite" number="6" />
+        <itemStack oreDictionary="crushedSodalite" number="4" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="LazuriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreLazurite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLazurite" number="6" />
+        <itemStack oreDictionary="crushedSodalite" number="4" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteLazuriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteLazurite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLazurite" number="6" />
+        <itemStack oreDictionary="crushedSodalite" number="4" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteLazuriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteLazurite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallLazurite" number="6" />
+        <itemStack oreDictionary="crushedSodalite" number="4" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackAlmandineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackAlmandine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAlmandine" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneAlmandineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneAlmandine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAlmandine" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="AlmandineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreAlmandine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAlmandine" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteAlmandineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteAlmandine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAlmandine" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteAlmandineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteAlmandine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallAlmandine" number="1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMolybdenumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMolybdenum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMolybdenumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMolybdenum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="MolybdenumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMolybdenum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMolybdenumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMolybdenum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMolybdenumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMolybdenum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackOlivineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackOlivine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallOlivine" number="1" />
+        <itemStack oreDictionary="crushedPyrope" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneOlivineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneOlivine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallOlivine" number="1" />
+        <itemStack oreDictionary="crushedPyrope" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="OlivineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreOlivine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallOlivine" number="1" />
+        <itemStack oreDictionary="crushedPyrope" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteOlivineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteOlivine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallOlivine" number="1" />
+        <itemStack oreDictionary="crushedPyrope" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteOlivineOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteOlivine" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallOlivine" number="1" />
+        <itemStack oreDictionary="crushedPyrope" number="1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackPyrolusiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackPyrolusite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPyrolusite" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstonePyrolusiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstonePyrolusite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPyrolusite" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="PyrolusiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="orePyrolusite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPyrolusite" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgranitePyrolusiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgranitePyrolusite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPyrolusite" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgranitePyrolusiteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgranitePyrolusite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallPyrolusite" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackMonaziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackMonazite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMonazite" number="8" />
+        <itemStack oreDictionary="crushedThorium" number="2" />
+        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneMonaziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneMonazite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMonazite" number="8" />
+        <itemStack oreDictionary="crushedThorium" number="2" />
+        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="MonaziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreMonazite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMonazite" number="8" />
+        <itemStack oreDictionary="crushedThorium" number="2" />
+        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteMonaziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteMonazite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMonazite" number="8" />
+        <itemStack oreDictionary="crushedThorium" number="2" />
+        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteMonaziteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteMonazite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallMonazite" number="8" />
+        <itemStack oreDictionary="crushedThorium" number="2" />
+        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.33" />
+        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackChalcopyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackChalcopyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallChalcopyrite" number="1" />
+        <itemStack oreDictionary="crushedPyrite" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneChalcopyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneChalcopyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallChalcopyrite" number="1" />
+        <itemStack oreDictionary="crushedPyrite" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="ChalcopyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreChalcopyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallChalcopyrite" number="1" />
+        <itemStack oreDictionary="crushedPyrite" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteChalcopyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteChalcopyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallChalcopyrite" number="1" />
+        <itemStack oreDictionary="crushedPyrite" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteChalcopyriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteChalcopyrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallChalcopyrite" number="1" />
+        <itemStack oreDictionary="crushedPyrite" number="1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackIridiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackIridium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIridium" number="1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneIridiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneIridium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIridium" number="1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="IridiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreIridium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIridium" number="1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteIridiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteIridium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIridium" number="1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteIridiumOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteIridium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallIridium" number="1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackTetrahedriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackTetrahedrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTetrahedrite" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneTetrahedriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneTetrahedrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTetrahedrite" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="TetrahedriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreTetrahedrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTetrahedrite" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteTetrahedriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteTetrahedrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTetrahedrite" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteTetrahedriteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteTetrahedrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallTetrahedrite" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackEmeraldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackEmerald" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallEmerald" number="1" />
+        <itemStack oreDictionary="crushedBeryllium" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneEmeraldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneEmerald" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallEmerald" number="1" />
+        <itemStack oreDictionary="crushedBeryllium" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EmeraldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEmerald" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallEmerald" number="1" />
+        <itemStack oreDictionary="crushedBeryllium" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteEmeraldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteEmerald" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallEmerald" number="1" />
+        <itemStack oreDictionary="crushedBeryllium" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteEmeraldOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteEmerald" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallEmerald" number="1" />
+        <itemStack oreDictionary="crushedBeryllium" number="1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="NetherrackStibniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreNetherrackStibnite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallStibnite" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="EndstoneStibniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreEndstoneStibnite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallStibnite" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="StibniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreStibnite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallStibnite" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="RedgraniteStibniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreRedgraniteStibnite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallStibnite" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.1" />
+      </output>
+    </recipe>
+    <recipe name="BlackgraniteStibniteOre" energyCost="32000">
+      <input>
+        <itemStack oreDictionary="oreBlackgraniteStibnite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSmallStibnite" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.33" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.1" />
       </output>
     </recipe>
   </recipeGroup>
 
 </SAGMillRecipes>
-  
-

--- a/scripts/enderio.zs
+++ b/scripts/enderio.zs
@@ -164,11 +164,6 @@ var wrench = <ore:craftingToolWrench>;
 var wrenchYeta = <EnderIO:itemYetaWrench>;
 
 # Recipe fixes
-recipes.remove(ballDarkSteel);
-recipes.addShaped(ballDarkSteel * 5, [
-	[null, ingotDarkSteel, null],
-	[ingotDarkSteel, ingotDarkSteel, ingotDarkSteel],
-	[null, ingotDarkSteel, null]]);
 recipes.remove(obsidianReinforced);
 recipes.addShaped(obsidianReinforced, [
 	[ingotDarkSteel, barsDarkSteel, ingotDarkSteel],
@@ -250,6 +245,8 @@ gearStone.remove(gearBasic);
 gearBasic.addTooltip(format.red(format.bold("This item is DISABLED!")));
 recipes.remove(alloySmelter);
 alloySmelter.addTooltip(format.red(format.bold("This item is DISABLED!")));
+recipes.remove(ballDarkSteel);
+ballDarkSteel.addTooltip(format.red(format.bold("This item is DISABLED!")));
 
 # Recipe Tweaks
 recipes.remove(probeConduit);

--- a/scripts/enderio.zs
+++ b/scripts/enderio.zs
@@ -127,7 +127,7 @@ var moltenPulsatingIron = <liquid:molten.pulsatingiron>;
 var moltenRedstone = <liquid:molten.redstone>;
 var moltenTin = <liquid:molten.tin>;
 var moltenVibrantAlloy = <liquid:molten.vibrantalloy>;
-var motorMV = <gregtech:gt.metaitem.01:32601>;
+var motorHV = <gregtech:gt.metaitem.01:32602>;
 var netherQuartz = <minecraft:quartz>;
 var nuggetEnderium = <ore:nuggetEnderium>;
 var nuggetPulsatingIron = <ore:nuggetPulsatingIron>;
@@ -140,7 +140,7 @@ var pipeSmallBronze = <ore:pipeSmallBronze>;
 var pipeSmallSteel = <ore:pipeSmallSteel>;
 var pipeSmallTungstenSteel = <ore:pipeSmallTungstenSteel>;
 var piston = <minecraft:piston>;
-var pistonMV = <gregtech:gt.metaitem.01:32641>;
+var pistonHV = <gregtech:gt.metaitem.01:32642>;
 var plateDarkSteel = <ore:plateDarkSteel>;
 var plateIron = <ore:plateIron>;
 var plateSilicon = <ore:plateSilicon>;
@@ -307,9 +307,9 @@ recipes.addShaped(tankFluid, [
     [plateIron, barsIron, plateIron]]);
 recipes.remove(sagMill);
 recipes.addShaped(sagMill, [
-    [ingotElectricalSteel, craftingGrinder, ingotElectricalSteel],
+    [plateDarkSteel, craftingGrinder, plateDarkSteel],
     [flint, machineChassis, flint],
-    [pistonMV, capacitorDualLayer, motorMV]]);
+    [pistonHV, capacitorDualLayer, motorHV]]);
 recipes.remove(generatorCombustion);
 recipes.addShaped(generatorCombustion, [
     [ingotElectricalSteel, ingotElectricalSteel, ingotElectricalSteel],


### PR DESCRIPTION
Makes it compatible with all GT ores, and as a machine that produces high amounts of byproducts but low amounts of the primary output.