### PR TITLE
Lowered absorber power production

### DIFF
--- a/config/GregTech/MachineStats.cfg
+++ b/config/GregTech/MachineStats.cfg
@@ -15,7 +15,7 @@ machineconfig {
     B:MagicEnergyAbsorber.AllowMultipleEggs_false=true
     I:MagicEnergyAbsorber.EnergyPerTick.EnderCrystal_32=32
     I:MagicEnergyAbsorber.EnergyPerTick_2048=5
-    I:MagicEnergyAbsorber.EnergyPerVisDivisor_2500=25
+    I:MagicEnergyAbsorber.EnergyPerVisDivisor_2500=250000
     I:MagicEnergyAbsorber.efficiency.tier.0_100=100
     I:MagicEnergyAbsorber.efficiency.tier.1_90=90
     I:MagicEnergyAbsorber.efficiency.tier.2_80=80

--- a/config/GregTech/MachineStats.cfg
+++ b/config/GregTech/MachineStats.cfg
@@ -14,8 +14,8 @@ machineconfig {
     I:GasTurbine.efficiency.tier.3_85=85
     B:MagicEnergyAbsorber.AllowMultipleEggs_false=true
     I:MagicEnergyAbsorber.EnergyPerTick.EnderCrystal_32=32
-    I:MagicEnergyAbsorber.EnergyPerTick_2048=2048
-    I:MagicEnergyAbsorber.EnergyPerVisDivisor_2500=2500
+    I:MagicEnergyAbsorber.EnergyPerTick_2048=5
+    I:MagicEnergyAbsorber.EnergyPerVisDivisor_2500=25
     I:MagicEnergyAbsorber.efficiency.tier.0_100=100
     I:MagicEnergyAbsorber.efficiency.tier.1_90=90
     I:MagicEnergyAbsorber.efficiency.tier.2_80=80


### PR DESCRIPTION
Egg - 500EU/t

reason the value is 1/100 in the config is because of current bug where there is set multiplier to 100x.
Will be raised after the bug is fixed in GT.

For reference: https://github.com/Blood-Asp/GT5-Unofficial/issues/486