### PR TITLE
Enabling the Last Millennium Dimension.

### DIFF
--- a/config/ExtraUtilities.cfg
+++ b/config/ExtraUtilities.cfg
@@ -28,7 +28,7 @@ blocks {
     B:MagnumTorchEnabled=true
     B:MiniChestEnabled=true
     B:PeacefultableEnabled=true
-    B:PortalEnabled=false
+    B:PortalEnabled=true
     B:PureLoveBlockEnabled=true
     B:QEDEnabled=true
     B:SlightlyLargerChestEnabled=true

--- a/scripts/extrautilities.zs
+++ b/scripts/extrautilities.zs
@@ -67,6 +67,7 @@ var sandCompressed = <ExtraUtilities:cobblestone_compressed:14>;
 var sandCompressed2 = <ExtraUtilities:cobblestone_compressed:15>;
 var schematic3x3 = <gregtech:gt.metaitem.01:32497>;
 var tradingPost = <ExtraUtilities:trading_post>;
+var portalDark = <ExtraUtilities:dark_portal>;
 
 # -- Block/item Removal
 recipes.remove(enderReceiver);
@@ -81,6 +82,8 @@ nodeEnergy.addTooltip(format.red(format.bold("This item is DISABLED!")));
 recipes.remove(nodeHyperEnergy);
 nodeHyperEnergy.addTooltip(format.red(format.bold("This item is DISABLED!")));
 
+recipes.remove(portalDark);
+portalDark.addTooltip(format.red(format.bold("This item is DISABLED!")));
 
 
 # ---Recipe tweaks---


### PR DESCRIPTION
Just edited the extra utilities config and the extra utilities script to enable the void dimension that extra utilities adds, but **not** allow users access to the deep dark.
Was considering changing the last millennium portal recipe to the QED, but it's just a void dimension so I left it as the default recipe.