### PR TITLE
opaque event horizon

### DIFF
--- a/config/SGCraft.cfg
+++ b/config/SGCraft.cfg
@@ -58,7 +58,7 @@ stargate {
     B:oneWayTravel=true
     I:secondsToStayOpen=450
     D:soundVolume=1.0
-    B:transparency=true
+    B:transparency=false
 }
 
 


### PR DESCRIPTION
In the series its only transparent when you look at it from behind but from the front its always opaque.
<img src="https://vignette3.wikia.nocookie.net/stargate/images/3/3f/02.jpg/revision/latest?cb=20081106213247">

It would also "fix" those kind of glitches.
<img src="http://i.imgur.com/fqlbHFh.gif" width="700px">

with this change it would look like this
<img src="http://i.imgur.com/k12hf42.jpg" width="700px">