### PR TITLE
Nerf SAG Mill

### DIFF
--- a/config/enderio/SAGMillRecipes_User.xml
+++ b/config/enderio/SAGMillRecipes_User.xml
@@ -120,7 +120,7 @@ found in the core file.
       </input>
       <output>
         <itemStack modID="minecraft" itemName="sand" />
-        <itemStack modID="minecraft" itemName="gravel" chance="0.1" />
+        <itemStack modID="minecraft" itemName="gravel" chance="0.025" />
       </output>
     </recipe>
     <recipe name="ClayBlock" energyCost="2400">
@@ -129,7 +129,117 @@ found in the core file.
       </input>
       <output>
         <itemStack modID="minecraft" itemName="clay_ball" number="2" />
-        <itemStack modID="minecraft" itemName="clay_ball" number="1" chance="0.1" />
+        <itemStack modID="minecraft" itemName="clay_ball" number="1" chance="0.025" />
+      </output>
+    </recipe>
+    <recipe name="Coal" energyCost="2400" >
+      <input>
+        <itemStack modID="minecraft" itemName="coal" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustCoal" number="1" />
+        <itemStack oreDictionary="dustCoal" number="1" chance="0.025" />
+        <itemStack oreDictionary="dustSulfur" number="1" chance="0.025" />
+      </output>
+    </recipe>
+    <recipe name="Sandstone" energyCost="2400" >
+      <input>
+        <itemStack oreDictionary="sandstone" />
+      </input>
+      <output>
+        <itemStack oreDictionary="sand" number="2" />
+        <itemStack oreDictionary="sand" number="2" chance="0.1" />
+        <itemStack oreDictionary="dustSaltpeter" number="1" chance ="0.04" />
+      </output>
+    </recipe>
+    <recipe name="Gravel" energyCost="2400" >
+      <input>
+        <itemStack oreDictionary="gravel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="itemFlint" />
+        <itemStack oreDictionary="itemFlint" chance="0.025" />
+        <itemStack oreDictionary="sand" chance="0.025" />
+      </output>
+    </recipe>
+    <recipe name="Netherrack" energyCost="2400" >
+      <input>
+        <itemStack modID="minecraft" itemName="netherrack" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSulfur" chance="0.04" />
+      </output>
+    </recipe>
+    <recipe name="BlazeRod" energyCost="2400" >
+      <input>
+        <itemStack modID="minecraft" itemName="blaze_rod" />
+      </input>
+      <output>
+        <itemStack modID="minecraft" itemName="blaze_powder" number="4" />
+        <itemStack oreDictionary="dustSulfur" chance="0.012" />
+      </output>
+    </recipe>
+    <recipe name="GlowStone" energyCost="2400" >
+      <input>
+        <itemStack modID="minecraft" itemName="glowstone" />
+      </input>
+      <output>
+        <itemStack modID="minecraft" itemName="glowstone_dust" number="3" />
+        <itemStack modID="minecraft" itemName="glowstone_dust" number="1" chance="0.2" />
+      </output>
+    </recipe>
+    <recipe name="Bone" energyCost="2400" >
+      <input>
+        <itemStack modID="minecraft" itemName="bone" />
+      </input>
+      <output>
+        <itemStack modID="minecraft" itemName="dye" itemMeta="15" number="6" />
+        <itemStack modID="minecraft" itemName="dye" itemMeta="15" number="2" chance="0.025" />
+      </output>
+    </recipe>
+    <recipe name="Wool" energyCost="1200" >
+      <input>
+        <itemStack modID="minecraft" itemName="wool" itemMeta="*" />
+      </input>
+      <output>
+        <itemStack modID="minecraft" itemName="string" number="3" />
+        <itemStack modID="minecraft" itemName="string" number="1" chance="0.025" />
+      </output>
+    </recipe>
+    <recipe name="Wheat" energyCost="800" >
+      <input>
+        <itemStack modID="minecraft" itemName="wheat" />
+      </input>
+      <output>
+        <itemStack modID="EnderIO" itemName="itemPowderIngot" itemMeta="8" number="2" />
+        <itemStack modID="minecraft" itemName="wheat_seeds" chance="0.05" />
+      </output>
+    </recipe>
+    <recipe name="Block of Quartz" energyCost="2400" >
+      <input>
+        <itemStack modID="minecraft" itemName="quartz_block" itemMeta="*" />
+      </input>
+      <output>
+        <itemStack modID="minecraft" itemName="quartz" number="2" />
+        <itemStack modID="minecraft" itemName="quartz" number="2" chance="0.07" />
+      </output>
+    </recipe>
+    <recipe name="Quartz Stairs" energyCost="1200" >
+      <input>
+        <itemStack modID="minecraft" itemName="quartz_stairs" />
+      </input>
+      <output>
+        <itemStack modID="minecraft" itemName="quartz" number="2" />
+        <itemStack modID="minecraft" itemName="quartz" number="2" chance="0.07" />
+      </output>
+    </recipe>
+    <recipe name="Quartz Slab" energyCost="1200" >
+      <input>
+        <itemStack modID="minecraft" itemName="stone_slab" itemMeta="7" />
+      </input>
+      <output>
+        <itemStack modID="minecraft" itemName="quartz" number="1" />
+        <itemStack modID="minecraft" itemName="quartz" number="1" chance="0.07" />
       </output>
     </recipe>
     <recipe name="RedstoneOre" />
@@ -148,6 +258,18 @@ found in the core file.
   
   <recipeGroup name="Biomes O' Plenty" enabled="false" />
 
+  <recipeGroup name="Big Reactors" >
+    <recipe name="YelloriteOre" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="oreYellorite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustYellorium" number="2" />
+        <itemStack oreDictionary="dustCyanite" number="1" chance="0.013" />
+      </output>
+    </recipe>
+  </recipeGroup>
+
   <recipeGroup name="TConstruct" enabled="false" />
 
   <recipeGroup name="Metallurgy" enabled="false" />
@@ -159,6 +281,57 @@ found in the core file.
 
   <recipeGroup name="Forestry" >
     <recipe name="ApatiteOre" />
+    <recipe name="Log" energyCost="2400" >
+      <input>
+        <itemStack oreDictionary="logWood" />
+      </input>
+      <output>
+        <itemStack oreDictionary="pulpWood" number="1" />
+        <itemStack oreDictionary="pulpWood" number="1" chance="0.225" />
+        <itemStack oreDictionary="pulpWood" number="1" chance="0.125" />
+        <itemStack oreDictionary="pulpWood" number="1" chance="0.025" />
+      </output>
+    </recipe>
+    <recipe name="Plank" energyCost="1200" >
+      <input>
+        <itemStack oreDictionary="plankWood" />
+      </input>
+      <output>
+        <itemStack oreDictionary="pulpWood" number="1" chance="0.225" />
+      </output>
+    </recipe>
+    <recipe name="Stairs" energyCost="1200" >
+      <input>
+        <itemStack oreDictionary="stairsWood" />
+      </input>
+      <output>
+        <itemStack oreDictionary="pulpWood" number="1" chance="0.2" />
+      </output>
+    </recipe>
+    <recipe name="Stair" energyCost="1200" >
+      <input>
+        <itemStack oreDictionary="stairWood" />
+      </input>
+      <output>
+        <itemStack oreDictionary="pulpWood" number="1" chance="0.225" />
+      </output>
+    </recipe>
+    <recipe name="SlabWood" energyCost="1200" >
+      <input>
+        <itemStack oreDictionary="slabWood" />
+      </input>
+      <output>
+        <itemStack oreDictionary="pulpWood" number="1" chance="0.175" />
+      </output>
+    </recipe>
+    <recipe name="Stick" energyCost="800" >
+      <input>
+        <itemStack oreDictionary="stickWood" />
+      </input>
+      <output>
+        <itemStack oreDictionary="pulpWood" number="1" chance="0.038" />
+      </output>
+    </recipe>
   </recipeGroup>
 
   <recipeGroup name="Mekanism" enabled="false" />
@@ -171,8 +344,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSodalite" number="6" />
         <itemStack oreDictionary="crushedLazurite" number="4" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSodaliteOre" energyCost="32000">
@@ -182,8 +355,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSodalite" number="6" />
         <itemStack oreDictionary="crushedLazurite" number="4" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SodaliteOre" energyCost="32000">
@@ -193,8 +366,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSodalite" number="6" />
         <itemStack oreDictionary="crushedLazurite" number="4" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSodaliteOre" energyCost="32000">
@@ -204,8 +377,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSodalite" number="6" />
         <itemStack oreDictionary="crushedLazurite" number="4" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSodaliteOre" energyCost="32000">
@@ -215,8 +388,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSodalite" number="6" />
         <itemStack oreDictionary="crushedLazurite" number="4" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackThoriumOre" energyCost="32000">
@@ -226,8 +399,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallThorium" number="1" />
         <itemStack oreDictionary="crushedUranium" number="1" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneThoriumOre" energyCost="32000">
@@ -237,8 +410,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallThorium" number="1" />
         <itemStack oreDictionary="crushedUranium" number="1" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="ThoriumOre" energyCost="32000">
@@ -248,8 +421,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallThorium" number="1" />
         <itemStack oreDictionary="crushedUranium" number="1" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteThoriumOre" energyCost="32000">
@@ -259,8 +432,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallThorium" number="1" />
         <itemStack oreDictionary="crushedUranium" number="1" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteThoriumOre" energyCost="32000">
@@ -270,8 +443,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallThorium" number="1" />
         <itemStack oreDictionary="crushedUranium" number="1" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackPyriteOre" energyCost="32000">
@@ -281,8 +454,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrite" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstonePyriteOre" energyCost="32000">
@@ -292,8 +465,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrite" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="PyriteOre" energyCost="32000">
@@ -303,8 +476,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrite" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgranitePyriteOre" energyCost="32000">
@@ -314,8 +487,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrite" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgranitePyriteOre" energyCost="32000">
@@ -325,8 +498,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrite" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackGrossularOre" energyCost="32000">
@@ -336,8 +509,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGrossular" number="1" />
         <itemStack oreDictionary="crushedGarnetYellow" number="1" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneGrossularOre" energyCost="32000">
@@ -347,8 +520,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGrossular" number="1" />
         <itemStack oreDictionary="crushedGarnetYellow" number="1" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="GrossularOre" energyCost="32000">
@@ -358,8 +531,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGrossular" number="1" />
         <itemStack oreDictionary="crushedGarnetYellow" number="1" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteGrossularOre" energyCost="32000">
@@ -369,8 +542,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGrossular" number="1" />
         <itemStack oreDictionary="crushedGarnetYellow" number="1" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteGrossularOre" energyCost="32000">
@@ -380,8 +553,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGrossular" number="1" />
         <itemStack oreDictionary="crushedGarnetYellow" number="1" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackLepidoliteOre" energyCost="32000">
@@ -391,8 +564,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLepidolite" number="1" />
         <itemStack oreDictionary="crushedLithium" number="1" />
-        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneLepidoliteOre" energyCost="32000">
@@ -402,8 +575,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLepidolite" number="1" />
         <itemStack oreDictionary="crushedLithium" number="1" />
-        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="LepidoliteOre" energyCost="32000">
@@ -413,8 +586,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLepidolite" number="1" />
         <itemStack oreDictionary="crushedLithium" number="1" />
-        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteLepidoliteOre" energyCost="32000">
@@ -424,8 +597,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLepidolite" number="1" />
         <itemStack oreDictionary="crushedLithium" number="1" />
-        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteLepidoliteOre" energyCost="32000">
@@ -435,8 +608,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLepidolite" number="1" />
         <itemStack oreDictionary="crushedLithium" number="1" />
-        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCaesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackPhosphorusOre" energyCost="32000">
@@ -446,8 +619,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPhosphorus" number="3" />
         <itemStack oreDictionary="crushedApatite" number="1" />
-        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstonePhosphorusOre" energyCost="32000">
@@ -457,8 +630,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPhosphorus" number="3" />
         <itemStack oreDictionary="crushedApatite" number="1" />
-        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="PhosphorusOre" energyCost="32000">
@@ -468,8 +641,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPhosphorus" number="3" />
         <itemStack oreDictionary="crushedApatite" number="1" />
-        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgranitePhosphorusOre" energyCost="32000">
@@ -479,8 +652,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPhosphorus" number="3" />
         <itemStack oreDictionary="crushedApatite" number="1" />
-        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgranitePhosphorusOre" energyCost="32000">
@@ -490,8 +663,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPhosphorus" number="3" />
         <itemStack oreDictionary="crushedApatite" number="1" />
-        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphate" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackSulfurOre" energyCost="32000">
@@ -501,8 +674,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSulfur" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSulfurOre" energyCost="32000">
@@ -512,8 +685,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSulfur" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SulfurOre" energyCost="32000">
@@ -523,8 +696,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSulfur" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSulfurOre" energyCost="32000">
@@ -534,8 +707,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSulfur" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSulfurOre" energyCost="32000">
@@ -545,8 +718,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSulfur" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackBariteOre" energyCost="32000">
@@ -556,8 +729,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBarite" number="1" />
         <itemStack oreDictionary="crushedBarite" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneBariteOre" energyCost="32000">
@@ -567,8 +740,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBarite" number="1" />
         <itemStack oreDictionary="crushedBarite" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BariteOre" energyCost="32000">
@@ -578,8 +751,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBarite" number="1" />
         <itemStack oreDictionary="crushedBarite" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteBariteOre" energyCost="32000">
@@ -589,8 +762,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBarite" number="1" />
         <itemStack oreDictionary="crushedBarite" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteBariteOre" energyCost="32000">
@@ -600,8 +773,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBarite" number="1" />
         <itemStack oreDictionary="crushedBarite" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackPentlanditeOre" energyCost="32000">
@@ -611,8 +784,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPentlandite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstonePentlanditeOre" energyCost="32000">
@@ -622,8 +795,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPentlandite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="PentlanditeOre" energyCost="32000">
@@ -633,8 +806,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPentlandite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgranitePentlanditeOre" energyCost="32000">
@@ -644,8 +817,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPentlandite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgranitePentlanditeOre" energyCost="32000">
@@ -655,8 +828,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPentlandite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackTantaliteOre" energyCost="32000">
@@ -666,8 +839,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTantalite" number="1" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="EndstoneTantaliteOre" energyCost="32000">
@@ -677,8 +850,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTantalite" number="1" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="TantaliteOre" energyCost="32000">
@@ -688,8 +861,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTantalite" number="1" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="RedgraniteTantaliteOre" energyCost="32000">
@@ -699,8 +872,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTantalite" number="1" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="BlackgraniteTantaliteOre" energyCost="32000">
@@ -710,8 +883,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTantalite" number="1" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNiobium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTantalum" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="NetherrackQuartziteOre" energyCost="32000">
@@ -721,8 +894,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallQuartzite" number="1" />
         <itemStack oreDictionary="crushedCertusQuartz" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneQuartziteOre" energyCost="32000">
@@ -732,8 +905,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallQuartzite" number="1" />
         <itemStack oreDictionary="crushedCertusQuartz" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="QuartziteOre" energyCost="32000">
@@ -743,8 +916,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallQuartzite" number="1" />
         <itemStack oreDictionary="crushedCertusQuartz" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteQuartziteOre" energyCost="32000">
@@ -754,8 +927,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallQuartzite" number="1" />
         <itemStack oreDictionary="crushedCertusQuartz" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteQuartziteOre" energyCost="32000">
@@ -765,8 +938,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallQuartzite" number="1" />
         <itemStack oreDictionary="crushedCertusQuartz" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackCoalOre" energyCost="32000">
@@ -776,8 +949,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCoal" number="1" />
         <itemStack oreDictionary="crushedLignite" number="1" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneCoalOre" energyCost="32000">
@@ -787,8 +960,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCoal" number="1" />
         <itemStack oreDictionary="crushedLignite" number="1" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="CoalOre" energyCost="32000">
@@ -798,8 +971,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCoal" number="1" />
         <itemStack oreDictionary="crushedLignite" number="1" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteCoalOre" energyCost="32000">
@@ -809,8 +982,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCoal" number="1" />
         <itemStack oreDictionary="crushedLignite" number="1" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteCoalOre" energyCost="32000">
@@ -820,8 +993,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCoal" number="1" />
         <itemStack oreDictionary="crushedLignite" number="1" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackScheeliteOre" energyCost="32000">
@@ -831,8 +1004,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallScheelite" number="2" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneScheeliteOre" energyCost="32000">
@@ -842,8 +1015,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallScheelite" number="2" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="ScheeliteOre" energyCost="32000">
@@ -853,8 +1026,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallScheelite" number="2" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteScheeliteOre" energyCost="32000">
@@ -864,8 +1037,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallScheelite" number="2" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteScheeliteOre" energyCost="32000">
@@ -875,8 +1048,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallScheelite" number="2" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackSilverOre" energyCost="32000">
@@ -886,8 +1059,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSilver" number="1" />
         <itemStack oreDictionary="crushedLead" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSilverOre" energyCost="32000">
@@ -897,8 +1070,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSilver" number="1" />
         <itemStack oreDictionary="crushedLead" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SilverOre" energyCost="32000">
@@ -908,8 +1081,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSilver" number="1" />
         <itemStack oreDictionary="crushedLead" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSilverOre" energyCost="32000">
@@ -919,8 +1092,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSilver" number="1" />
         <itemStack oreDictionary="crushedLead" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSilverOre" energyCost="32000">
@@ -930,8 +1103,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSilver" number="1" />
         <itemStack oreDictionary="crushedLead" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackLeadOre" energyCost="32000">
@@ -941,8 +1114,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLead" number="1" />
         <itemStack oreDictionary="crushedSilver" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneLeadOre" energyCost="32000">
@@ -952,8 +1125,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLead" number="1" />
         <itemStack oreDictionary="crushedSilver" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="LeadOre" energyCost="32000">
@@ -963,8 +1136,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLead" number="1" />
         <itemStack oreDictionary="crushedSilver" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteLeadOre" energyCost="32000">
@@ -974,8 +1147,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLead" number="1" />
         <itemStack oreDictionary="crushedSilver" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteLeadOre" energyCost="32000">
@@ -985,8 +1158,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLead" number="1" />
         <itemStack oreDictionary="crushedSilver" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackSpodumeneOre" energyCost="32000">
@@ -996,8 +1169,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSpodumene" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSpodumeneOre" energyCost="32000">
@@ -1007,8 +1180,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSpodumene" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SpodumeneOre" energyCost="32000">
@@ -1018,8 +1191,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSpodumene" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSpodumeneOre" energyCost="32000">
@@ -1029,8 +1202,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSpodumene" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSpodumeneOre" energyCost="32000">
@@ -1040,8 +1213,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSpodumene" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackBrownLimoniteOre" energyCost="32000">
@@ -1051,8 +1224,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBrownLimonite" number="1" />
         <itemStack oreDictionary="crushedMalachite" number="1" />
-        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneBrownLimoniteOre" energyCost="32000">
@@ -1062,8 +1235,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBrownLimonite" number="1" />
         <itemStack oreDictionary="crushedMalachite" number="1" />
-        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BrownLimoniteOre" energyCost="32000">
@@ -1073,8 +1246,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBrownLimonite" number="1" />
         <itemStack oreDictionary="crushedMalachite" number="1" />
-        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteBrownLimoniteOre" energyCost="32000">
@@ -1084,8 +1257,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBrownLimonite" number="1" />
         <itemStack oreDictionary="crushedMalachite" number="1" />
-        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteBrownLimoniteOre" energyCost="32000">
@@ -1095,8 +1268,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBrownLimonite" number="1" />
         <itemStack oreDictionary="crushedMalachite" number="1" />
-        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedYellowLimonite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackLigniteOre" energyCost="32000">
@@ -1106,8 +1279,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLignite" number="1" />
         <itemStack oreDictionary="crushedCoal" number="1" />
-        <itemStack oreDictionary="crushedCoal" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCoal" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneLigniteOre" energyCost="32000">
@@ -1117,8 +1290,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLignite" number="1" />
         <itemStack oreDictionary="crushedCoal" number="1" />
-        <itemStack oreDictionary="crushedCoal" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCoal" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="LigniteOre" energyCost="32000">
@@ -1128,8 +1301,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLignite" number="1" />
         <itemStack oreDictionary="crushedCoal" number="1" />
-        <itemStack oreDictionary="crushedCoal" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCoal" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteLigniteOre" energyCost="32000">
@@ -1139,8 +1312,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLignite" number="1" />
         <itemStack oreDictionary="crushedCoal" number="1" />
-        <itemStack oreDictionary="crushedCoal" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCoal" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteLigniteOre" energyCost="32000">
@@ -1150,8 +1323,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLignite" number="1" />
         <itemStack oreDictionary="crushedCoal" number="1" />
-        <itemStack oreDictionary="crushedCoal" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCoal" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCoal" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackPhosphateOre" energyCost="32000">
@@ -1161,8 +1334,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPhosphate" number="1" />
         <itemStack oreDictionary="crushedPhosphor" number="1" />
-        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstonePhosphateOre" energyCost="32000">
@@ -1172,8 +1345,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPhosphate" number="1" />
         <itemStack oreDictionary="crushedPhosphor" number="1" />
-        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="PhosphateOre" energyCost="32000">
@@ -1183,8 +1356,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPhosphate" number="1" />
         <itemStack oreDictionary="crushedPhosphor" number="1" />
-        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgranitePhosphateOre" energyCost="32000">
@@ -1194,8 +1367,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPhosphate" number="1" />
         <itemStack oreDictionary="crushedPhosphor" number="1" />
-        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgranitePhosphateOre" energyCost="32000">
@@ -1205,8 +1378,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPhosphate" number="1" />
         <itemStack oreDictionary="crushedPhosphor" number="1" />
-        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphor" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackDiamondOre" energyCost="32000">
@@ -1216,8 +1389,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallDiamond" number="1" />
         <itemStack oreDictionary="crushedGraphite" number="1" />
-        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneDiamondOre" energyCost="32000">
@@ -1227,8 +1400,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallDiamond" number="1" />
         <itemStack oreDictionary="crushedGraphite" number="1" />
-        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="DiamondOre" energyCost="32000">
@@ -1238,8 +1411,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallDiamond" number="1" />
         <itemStack oreDictionary="crushedGraphite" number="1" />
-        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteDiamondOre" energyCost="32000">
@@ -1249,8 +1422,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallDiamond" number="1" />
         <itemStack oreDictionary="crushedGraphite" number="1" />
-        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteDiamondOre" energyCost="32000">
@@ -1260,8 +1433,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallDiamond" number="1" />
         <itemStack oreDictionary="crushedGraphite" number="1" />
-        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGraphite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackPlatinumOre" energyCost="32000">
@@ -1271,8 +1444,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPlatinum" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstonePlatinumOre" energyCost="32000">
@@ -1282,8 +1455,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPlatinum" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="PlatinumOre" energyCost="32000">
@@ -1293,8 +1466,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPlatinum" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgranitePlatinumOre" energyCost="32000">
@@ -1304,8 +1477,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPlatinum" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgranitePlatinumOre" energyCost="32000">
@@ -1315,8 +1488,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPlatinum" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackYellowLimoniteOre" energyCost="32000">
@@ -1326,8 +1499,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallYellowLimonite" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneYellowLimoniteOre" energyCost="32000">
@@ -1337,8 +1510,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallYellowLimonite" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="YellowLimoniteOre" energyCost="32000">
@@ -1348,8 +1521,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallYellowLimonite" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteYellowLimoniteOre" energyCost="32000">
@@ -1359,8 +1532,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallYellowLimonite" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteYellowLimoniteOre" energyCost="32000">
@@ -1370,8 +1543,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallYellowLimonite" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackCobaltiteOre" energyCost="32000">
@@ -1381,8 +1554,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCobaltite" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneCobaltiteOre" energyCost="32000">
@@ -1392,8 +1565,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCobaltite" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="CobaltiteOre" energyCost="32000">
@@ -1403,8 +1576,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCobaltite" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteCobaltiteOre" energyCost="32000">
@@ -1414,8 +1587,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCobaltite" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteCobaltiteOre" energyCost="32000">
@@ -1425,8 +1598,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCobaltite" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackLapisOre" energyCost="32000">
@@ -1436,8 +1609,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLapis" number="6" />
         <itemStack oreDictionary="crushedLazurite" number="4" />
-        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneLapisOre" energyCost="32000">
@@ -1447,8 +1620,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLapis" number="6" />
         <itemStack oreDictionary="crushedLazurite" number="4" />
-        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="LapisOre" energyCost="32000">
@@ -1458,8 +1631,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLapis" number="6" />
         <itemStack oreDictionary="crushedLazurite" number="4" />
-        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteLapisOre" energyCost="32000">
@@ -1469,8 +1642,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLapis" number="6" />
         <itemStack oreDictionary="crushedLazurite" number="4" />
-        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteLapisOre" energyCost="32000">
@@ -1480,8 +1653,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLapis" number="6" />
         <itemStack oreDictionary="crushedLazurite" number="4" />
-        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedSodalite" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedPyrite" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackVanadiumMagnetiteOre" energyCost="32000">
@@ -1491,8 +1664,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallVanadiumMagnetite" number="1" />
         <itemStack oreDictionary="crushedMagnetite" number="1" />
-        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneVanadiumMagnetiteOre" energyCost="32000">
@@ -1502,8 +1675,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallVanadiumMagnetite" number="1" />
         <itemStack oreDictionary="crushedMagnetite" number="1" />
-        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="VanadiumMagnetiteOre" energyCost="32000">
@@ -1513,8 +1686,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallVanadiumMagnetite" number="1" />
         <itemStack oreDictionary="crushedMagnetite" number="1" />
-        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteVanadiumMagnetiteOre" energyCost="32000">
@@ -1524,8 +1697,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallVanadiumMagnetite" number="1" />
         <itemStack oreDictionary="crushedMagnetite" number="1" />
-        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteVanadiumMagnetiteOre" energyCost="32000">
@@ -1535,8 +1708,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallVanadiumMagnetite" number="1" />
         <itemStack oreDictionary="crushedMagnetite" number="1" />
-        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedVanadium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackSaltOre" energyCost="32000">
@@ -1546,8 +1719,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSalt" number="2" />
         <itemStack oreDictionary="crushedRockSalt" number="1" />
-        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSaltOre" energyCost="32000">
@@ -1557,8 +1730,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSalt" number="2" />
         <itemStack oreDictionary="crushedRockSalt" number="1" />
-        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SaltOre" energyCost="32000">
@@ -1568,8 +1741,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSalt" number="2" />
         <itemStack oreDictionary="crushedRockSalt" number="1" />
-        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSaltOre" energyCost="32000">
@@ -1579,8 +1752,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSalt" number="2" />
         <itemStack oreDictionary="crushedRockSalt" number="1" />
-        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSaltOre" energyCost="32000">
@@ -1590,8 +1763,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSalt" number="2" />
         <itemStack oreDictionary="crushedRockSalt" number="1" />
-        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedRockSalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackCassiteriteOre" energyCost="32000">
@@ -1601,8 +1774,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCassiterite" number="2" />
         <itemStack oreDictionary="crushedTin" number="1" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneCassiteriteOre" energyCost="32000">
@@ -1612,8 +1785,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCassiterite" number="2" />
         <itemStack oreDictionary="crushedTin" number="1" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="CassiteriteOre" energyCost="32000">
@@ -1623,8 +1796,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCassiterite" number="2" />
         <itemStack oreDictionary="crushedTin" number="1" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteCassiteriteOre" energyCost="32000">
@@ -1634,8 +1807,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCassiterite" number="2" />
         <itemStack oreDictionary="crushedTin" number="1" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteCassiteriteOre" energyCost="32000">
@@ -1645,8 +1818,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCassiterite" number="2" />
         <itemStack oreDictionary="crushedTin" number="1" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackNickelOre" energyCost="32000">
@@ -1656,8 +1829,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNickel" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneNickelOre" energyCost="32000">
@@ -1667,8 +1840,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNickel" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NickelOre" energyCost="32000">
@@ -1678,8 +1851,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNickel" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteNickelOre" energyCost="32000">
@@ -1689,8 +1862,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNickel" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteNickelOre" energyCost="32000">
@@ -1700,8 +1873,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNickel" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPlatinum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackMalachiteOre" energyCost="32000">
@@ -1711,8 +1884,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMalachite" number="1" />
         <itemStack oreDictionary="crushedCopper" number="1" />
-        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneMalachiteOre" energyCost="32000">
@@ -1722,8 +1895,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMalachite" number="1" />
         <itemStack oreDictionary="crushedCopper" number="1" />
-        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="MalachiteOre" energyCost="32000">
@@ -1733,8 +1906,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMalachite" number="1" />
         <itemStack oreDictionary="crushedCopper" number="1" />
-        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteMalachiteOre" energyCost="32000">
@@ -1744,8 +1917,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMalachite" number="1" />
         <itemStack oreDictionary="crushedCopper" number="1" />
-        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteMalachiteOre" energyCost="32000">
@@ -1755,8 +1928,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMalachite" number="1" />
         <itemStack oreDictionary="crushedCopper" number="1" />
-        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBrownLimonite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCalcite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackIronOre" energyCost="32000">
@@ -1766,8 +1939,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIron" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneIronOre" energyCost="32000">
@@ -1777,8 +1950,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIron" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="IronOre" energyCost="32000">
@@ -1788,8 +1961,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIron" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteIronOre" energyCost="32000">
@@ -1799,8 +1972,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIron" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteIronOre" energyCost="32000">
@@ -1810,8 +1983,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIron" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedTin" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedTin" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackRockSaltOre" energyCost="32000">
@@ -1821,8 +1994,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRockSalt" number="2" />
         <itemStack oreDictionary="crushedSalt" number="1" />
-        <itemStack oreDictionary="crushedSalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneRockSaltOre" energyCost="32000">
@@ -1832,8 +2005,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRockSalt" number="2" />
         <itemStack oreDictionary="crushedSalt" number="1" />
-        <itemStack oreDictionary="crushedSalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RockSaltOre" energyCost="32000">
@@ -1843,8 +2016,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRockSalt" number="2" />
         <itemStack oreDictionary="crushedSalt" number="1" />
-        <itemStack oreDictionary="crushedSalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteRockSaltOre" energyCost="32000">
@@ -1854,8 +2027,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRockSalt" number="2" />
         <itemStack oreDictionary="crushedSalt" number="1" />
-        <itemStack oreDictionary="crushedSalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteRockSaltOre" energyCost="32000">
@@ -1865,8 +2038,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRockSalt" number="2" />
         <itemStack oreDictionary="crushedSalt" number="1" />
-        <itemStack oreDictionary="crushedSalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSalt" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSalt" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackPalladiumOre" energyCost="32000">
@@ -1876,8 +2049,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPalladium" number="1" />
         <itemStack oreDictionary="crushedPalladium" number="1" />
-        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstonePalladiumOre" energyCost="32000">
@@ -1887,8 +2060,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPalladium" number="1" />
         <itemStack oreDictionary="crushedPalladium" number="1" />
-        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="PalladiumOre" energyCost="32000">
@@ -1898,8 +2071,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPalladium" number="1" />
         <itemStack oreDictionary="crushedPalladium" number="1" />
-        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgranitePalladiumOre" energyCost="32000">
@@ -1909,8 +2082,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPalladium" number="1" />
         <itemStack oreDictionary="crushedPalladium" number="1" />
-        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgranitePalladiumOre" energyCost="32000">
@@ -1920,8 +2093,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPalladium" number="1" />
         <itemStack oreDictionary="crushedPalladium" number="1" />
-        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPalladium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackCheeseOre" energyCost="32000">
@@ -1931,8 +2104,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCheese" number="1" />
         <itemStack oreDictionary="crushedCheese" number="1" />
-        <itemStack oreDictionary="crushedCheese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCheese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneCheeseOre" energyCost="32000">
@@ -1942,8 +2115,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCheese" number="1" />
         <itemStack oreDictionary="crushedCheese" number="1" />
-        <itemStack oreDictionary="crushedCheese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCheese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="CheeseOre" energyCost="32000">
@@ -1953,8 +2126,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCheese" number="1" />
         <itemStack oreDictionary="crushedCheese" number="1" />
-        <itemStack oreDictionary="crushedCheese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCheese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteCheeseOre" energyCost="32000">
@@ -1964,8 +2137,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCheese" number="1" />
         <itemStack oreDictionary="crushedCheese" number="1" />
-        <itemStack oreDictionary="crushedCheese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCheese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteCheeseOre" energyCost="32000">
@@ -1975,8 +2148,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCheese" number="1" />
         <itemStack oreDictionary="crushedCheese" number="1" />
-        <itemStack oreDictionary="crushedCheese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedCheese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedCheese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackTungstateOre" energyCost="32000">
@@ -1986,8 +2159,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTungstate" number="2" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="EndstoneTungstateOre" energyCost="32000">
@@ -1997,8 +2170,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTungstate" number="2" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="TungstateOre" energyCost="32000">
@@ -2008,8 +2181,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTungstate" number="2" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="RedgraniteTungstateOre" energyCost="32000">
@@ -2019,8 +2192,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTungstate" number="2" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="BlackgraniteTungstateOre" energyCost="32000">
@@ -2030,8 +2203,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTungstate" number="2" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="NetherrackBerylliumOre" energyCost="32000">
@@ -2041,8 +2214,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBeryllium" number="1" />
         <itemStack oreDictionary="crushedEmerald" number="1" />
-        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneBerylliumOre" energyCost="32000">
@@ -2052,8 +2225,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBeryllium" number="1" />
         <itemStack oreDictionary="crushedEmerald" number="1" />
-        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BerylliumOre" energyCost="32000">
@@ -2063,8 +2236,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBeryllium" number="1" />
         <itemStack oreDictionary="crushedEmerald" number="1" />
-        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteBerylliumOre" energyCost="32000">
@@ -2074,8 +2247,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBeryllium" number="1" />
         <itemStack oreDictionary="crushedEmerald" number="1" />
-        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteBerylliumOre" energyCost="32000">
@@ -2085,8 +2258,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBeryllium" number="1" />
         <itemStack oreDictionary="crushedEmerald" number="1" />
-        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedEmerald" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackBauxiteOre" energyCost="32000">
@@ -2096,8 +2269,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBauxite" number="1" />
         <itemStack oreDictionary="crushedGrossular" number="1" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGallium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGallium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="EndstoneBauxiteOre" energyCost="32000">
@@ -2107,8 +2280,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBauxite" number="1" />
         <itemStack oreDictionary="crushedGrossular" number="1" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGallium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGallium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="BauxiteOre" energyCost="32000">
@@ -2118,8 +2291,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBauxite" number="1" />
         <itemStack oreDictionary="crushedGrossular" number="1" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGallium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGallium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="RedgraniteBauxiteOre" energyCost="32000">
@@ -2129,8 +2302,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBauxite" number="1" />
         <itemStack oreDictionary="crushedGrossular" number="1" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGallium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGallium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="BlackgraniteBauxiteOre" energyCost="32000">
@@ -2140,8 +2313,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBauxite" number="1" />
         <itemStack oreDictionary="crushedGrossular" number="1" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGallium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGallium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="NetherrackCalciteOre" energyCost="32000">
@@ -2151,8 +2324,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCalcite" number="1" />
         <itemStack oreDictionary="crushedAndradite" number="1" />
-        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneCalciteOre" energyCost="32000">
@@ -2162,8 +2335,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCalcite" number="1" />
         <itemStack oreDictionary="crushedAndradite" number="1" />
-        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="CalciteOre" energyCost="32000">
@@ -2173,8 +2346,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCalcite" number="1" />
         <itemStack oreDictionary="crushedAndradite" number="1" />
-        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteCalciteOre" energyCost="32000">
@@ -2184,8 +2357,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCalcite" number="1" />
         <itemStack oreDictionary="crushedAndradite" number="1" />
-        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteCalciteOre" energyCost="32000">
@@ -2195,8 +2368,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCalcite" number="1" />
         <itemStack oreDictionary="crushedAndradite" number="1" />
-        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMalachite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackNaquadahOre" energyCost="32000">
@@ -2206,8 +2379,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNaquadah" number="1" />
         <itemStack oreDictionary="crushedNaquadahEnriched" number="1" />
-        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneNaquadahOre" energyCost="32000">
@@ -2217,8 +2390,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNaquadah" number="1" />
         <itemStack oreDictionary="crushedNaquadahEnriched" number="1" />
-        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NaquadahOre" energyCost="32000">
@@ -2228,8 +2401,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNaquadah" number="1" />
         <itemStack oreDictionary="crushedNaquadahEnriched" number="1" />
-        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteNaquadahOre" energyCost="32000">
@@ -2239,8 +2412,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNaquadah" number="1" />
         <itemStack oreDictionary="crushedNaquadahEnriched" number="1" />
-        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteNaquadahOre" energyCost="32000">
@@ -2250,8 +2423,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNaquadah" number="1" />
         <itemStack oreDictionary="crushedNaquadahEnriched" number="1" />
-        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNaquadahEnriched" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackSphaleriteOre" energyCost="32000">
@@ -2261,8 +2434,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSphalerite" number="1" />
         <itemStack oreDictionary="crushedGarnetYellow" number="1" />
-        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSphaleriteOre" energyCost="32000">
@@ -2272,8 +2445,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSphalerite" number="1" />
         <itemStack oreDictionary="crushedGarnetYellow" number="1" />
-        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SphaleriteOre" energyCost="32000">
@@ -2283,8 +2456,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSphalerite" number="1" />
         <itemStack oreDictionary="crushedGarnetYellow" number="1" />
-        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSphaleriteOre" energyCost="32000">
@@ -2294,8 +2467,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSphalerite" number="1" />
         <itemStack oreDictionary="crushedGarnetYellow" number="1" />
-        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSphaleriteOre" energyCost="32000">
@@ -2305,8 +2478,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSphalerite" number="1" />
         <itemStack oreDictionary="crushedGarnetYellow" number="1" />
-        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCadmium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackCooperiteOre" energyCost="32000">
@@ -2316,8 +2489,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCooperite" number="1" />
         <itemStack oreDictionary="crushedPalladium" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="EndstoneCooperiteOre" energyCost="32000">
@@ -2327,8 +2500,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCooperite" number="1" />
         <itemStack oreDictionary="crushedPalladium" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="CooperiteOre" energyCost="32000">
@@ -2338,8 +2511,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCooperite" number="1" />
         <itemStack oreDictionary="crushedPalladium" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="RedgraniteCooperiteOre" energyCost="32000">
@@ -2349,8 +2522,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCooperite" number="1" />
         <itemStack oreDictionary="crushedPalladium" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="BlackgraniteCooperiteOre" energyCost="32000">
@@ -2360,8 +2533,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCooperite" number="1" />
         <itemStack oreDictionary="crushedPalladium" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIridium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIridium" number="1" chance="0.15" />
       </output>
     </recipe>
     <recipe name="NetherrackNeodymiumOre" energyCost="32000">
@@ -2371,8 +2544,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNeodymium" number="1" />
         <itemStack oreDictionary="crushedMonazite" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneNeodymiumOre" energyCost="32000">
@@ -2382,8 +2555,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNeodymium" number="1" />
         <itemStack oreDictionary="crushedMonazite" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NeodymiumOre" energyCost="32000">
@@ -2393,8 +2566,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNeodymium" number="1" />
         <itemStack oreDictionary="crushedMonazite" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteNeodymiumOre" energyCost="32000">
@@ -2404,8 +2577,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNeodymium" number="1" />
         <itemStack oreDictionary="crushedMonazite" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteNeodymiumOre" energyCost="32000">
@@ -2415,8 +2588,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNeodymium" number="1" />
         <itemStack oreDictionary="crushedMonazite" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackApatiteOre" energyCost="32000">
@@ -2426,8 +2599,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallApatite" number="4" />
         <itemStack oreDictionary="crushedPhosphorus" number="2" />
-        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneApatiteOre" energyCost="32000">
@@ -2437,8 +2610,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallApatite" number="4" />
         <itemStack oreDictionary="crushedPhosphorus" number="2" />
-        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.015" />
       </output>
     </recipe>
     <recipe name="ApatiteOre" energyCost="32000">
@@ -2448,8 +2621,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallApatite" number="4" />
         <itemStack oreDictionary="crushedPhosphorus" number="2" />
-        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteApatiteOre" energyCost="32000">
@@ -2459,8 +2632,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallApatite" number="4" />
         <itemStack oreDictionary="crushedPhosphorus" number="2" />
-        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteApatiteOre" energyCost="32000">
@@ -2470,8 +2643,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallApatite" number="4" />
         <itemStack oreDictionary="crushedPhosphorus" number="2" />
-        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.33" />
-        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.1" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.06" />
+        <itemStack oreDictionary="crushedPhosphorus" number="2" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackAluminiumOre" energyCost="32000">
@@ -2481,8 +2654,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAluminium" number="1" />
         <itemStack oreDictionary="crushedBauxite" number="1" />
-        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneAluminiumOre" energyCost="32000">
@@ -2492,8 +2665,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAluminium" number="1" />
         <itemStack oreDictionary="crushedBauxite" number="1" />
-        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="AluminiumOre" energyCost="32000">
@@ -2503,8 +2676,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAluminium" number="1" />
         <itemStack oreDictionary="crushedBauxite" number="1" />
-        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteAluminiumOre" energyCost="32000">
@@ -2514,8 +2687,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAluminium" number="1" />
         <itemStack oreDictionary="crushedBauxite" number="1" />
-        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteAluminiumOre" energyCost="32000">
@@ -2525,8 +2698,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAluminium" number="1" />
         <itemStack oreDictionary="crushedBauxite" number="1" />
-        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBauxite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackAmberOre" energyCost="32000">
@@ -2536,8 +2709,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAmber" number="2" />
         <itemStack oreDictionary="crushedAmber" number="1" />
-        <itemStack oreDictionary="crushedAmber" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAmber" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneAmberOre" energyCost="32000">
@@ -2547,8 +2720,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAmber" number="2" />
         <itemStack oreDictionary="crushedAmber" number="1" />
-        <itemStack oreDictionary="crushedAmber" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAmber" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="AmberOre" energyCost="32000">
@@ -2558,8 +2731,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAmber" number="2" />
         <itemStack oreDictionary="crushedAmber" number="1" />
-        <itemStack oreDictionary="crushedAmber" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAmber" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteAmberOre" energyCost="32000">
@@ -2569,8 +2742,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAmber" number="2" />
         <itemStack oreDictionary="crushedAmber" number="1" />
-        <itemStack oreDictionary="crushedAmber" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAmber" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteAmberOre" energyCost="32000">
@@ -2580,8 +2753,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAmber" number="2" />
         <itemStack oreDictionary="crushedAmber" number="1" />
-        <itemStack oreDictionary="crushedAmber" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAmber" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAmber" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackUraniniteOre" energyCost="32000">
@@ -2591,8 +2764,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallUraninite" number="1" />
         <itemStack oreDictionary="crushedUranium" number="1" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="151.1" />
       </output>
     </recipe>
     <recipe name="EndstoneUraniniteOre" energyCost="32000">
@@ -2602,8 +2775,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallUraninite" number="1" />
         <itemStack oreDictionary="crushedUranium" number="1" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="151.1" />
       </output>
     </recipe>
     <recipe name="UraniniteOre" energyCost="32000">
@@ -2613,8 +2786,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallUraninite" number="1" />
         <itemStack oreDictionary="crushedUranium" number="1" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="151.1" />
       </output>
     </recipe>
     <recipe name="RedgraniteUraniniteOre" energyCost="32000">
@@ -2624,8 +2797,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallUraninite" number="1" />
         <itemStack oreDictionary="crushedUranium" number="1" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="151.1" />
       </output>
     </recipe>
     <recipe name="BlackgraniteUraniniteOre" energyCost="32000">
@@ -2635,8 +2808,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallUraninite" number="1" />
         <itemStack oreDictionary="crushedUranium" number="1" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="151.1" />
       </output>
     </recipe>
     <recipe name="NetherrackGalenaOre" energyCost="32000">
@@ -2646,8 +2819,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGalena" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneGalenaOre" energyCost="32000">
@@ -2657,8 +2830,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGalena" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="GalenaOre" energyCost="32000">
@@ -2668,8 +2841,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGalena" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteGalenaOre" energyCost="32000">
@@ -2679,8 +2852,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGalena" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteGalenaOre" energyCost="32000">
@@ -2690,8 +2863,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGalena" number="1" />
         <itemStack oreDictionary="crushedSulfur" number="1" />
-        <itemStack oreDictionary="crushedSilver" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSilver" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackNetherQuartzOre" energyCost="32000">
@@ -2701,8 +2874,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNetherQuartz" number="2" />
         <itemStack oreDictionary="dustNetherrack" number="1" />
-        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneNetherQuartzOre" energyCost="32000">
@@ -2712,8 +2885,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNetherQuartz" number="2" />
         <itemStack oreDictionary="dustNetherrack" number="1" />
-        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherQuartzOre" energyCost="32000">
@@ -2723,8 +2896,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNetherQuartz" number="2" />
         <itemStack oreDictionary="dustNetherrack" number="1" />
-        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteNetherQuartzOre" energyCost="32000">
@@ -2734,8 +2907,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNetherQuartz" number="2" />
         <itemStack oreDictionary="dustNetherrack" number="1" />
-        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteNetherQuartzOre" energyCost="32000">
@@ -2745,8 +2918,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallNetherQuartz" number="2" />
         <itemStack oreDictionary="dustNetherrack" number="1" />
-        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustNetherrack" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackRubyOre" energyCost="32000">
@@ -2756,8 +2929,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRuby" number="1" />
         <itemStack oreDictionary="crushedChrome" number="1" />
-        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneRubyOre" energyCost="32000">
@@ -2767,8 +2940,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRuby" number="1" />
         <itemStack oreDictionary="crushedChrome" number="1" />
-        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RubyOre" energyCost="32000">
@@ -2778,8 +2951,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRuby" number="1" />
         <itemStack oreDictionary="crushedChrome" number="1" />
-        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteRubyOre" energyCost="32000">
@@ -2789,8 +2962,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRuby" number="1" />
         <itemStack oreDictionary="crushedChrome" number="1" />
-        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteRubyOre" energyCost="32000">
@@ -2800,8 +2973,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRuby" number="1" />
         <itemStack oreDictionary="crushedChrome" number="1" />
-        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGarnetRed" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackGarnieriteOre" energyCost="32000">
@@ -2811,8 +2984,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGarnierite" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneGarnieriteOre" energyCost="32000">
@@ -2822,8 +2995,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGarnierite" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="GarnieriteOre" energyCost="32000">
@@ -2833,8 +3006,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGarnierite" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteGarnieriteOre" energyCost="32000">
@@ -2844,8 +3017,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGarnierite" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteGarnieriteOre" energyCost="32000">
@@ -2855,8 +3028,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGarnierite" number="1" />
         <itemStack oreDictionary="crushedNickel" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackIlmeniteOre" energyCost="32000">
@@ -2866,8 +3039,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIlmenite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneIlmeniteOre" energyCost="32000">
@@ -2877,8 +3050,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIlmenite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="IlmeniteOre" energyCost="32000">
@@ -2888,8 +3061,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIlmenite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteIlmeniteOre" energyCost="32000">
@@ -2899,8 +3072,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIlmenite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteIlmeniteOre" energyCost="32000">
@@ -2910,8 +3083,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIlmenite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedRutile" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedRutile" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackDeshOre" energyCost="32000">
@@ -2921,8 +3094,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallDesh" number="1" />
         <itemStack oreDictionary="crushedDesh" number="1" />
-        <itemStack oreDictionary="crushedDesh" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedDesh" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneDeshOre" energyCost="32000">
@@ -2932,8 +3105,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallDesh" number="1" />
         <itemStack oreDictionary="crushedDesh" number="1" />
-        <itemStack oreDictionary="crushedDesh" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedDesh" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="DeshOre" energyCost="32000">
@@ -2943,8 +3116,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallDesh" number="1" />
         <itemStack oreDictionary="crushedDesh" number="1" />
-        <itemStack oreDictionary="crushedDesh" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedDesh" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteDeshOre" energyCost="32000">
@@ -2954,8 +3127,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallDesh" number="1" />
         <itemStack oreDictionary="crushedDesh" number="1" />
-        <itemStack oreDictionary="crushedDesh" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedDesh" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteDeshOre" energyCost="32000">
@@ -2965,8 +3138,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallDesh" number="1" />
         <itemStack oreDictionary="crushedDesh" number="1" />
-        <itemStack oreDictionary="crushedDesh" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedDesh" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedDesh" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackCertusQuartzOre" energyCost="32000">
@@ -2976,8 +3149,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCertusQuartz" number="2" />
         <itemStack oreDictionary="crushedQuartzite" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneCertusQuartzOre" energyCost="32000">
@@ -2987,8 +3160,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCertusQuartz" number="2" />
         <itemStack oreDictionary="crushedQuartzite" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="CertusQuartzOre" energyCost="32000">
@@ -2998,8 +3171,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCertusQuartz" number="2" />
         <itemStack oreDictionary="crushedQuartzite" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteCertusQuartzOre" energyCost="32000">
@@ -3009,8 +3182,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCertusQuartz" number="2" />
         <itemStack oreDictionary="crushedQuartzite" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteCertusQuartzOre" energyCost="32000">
@@ -3020,8 +3193,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCertusQuartz" number="2" />
         <itemStack oreDictionary="crushedQuartzite" number="1" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBarite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBarite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackMolybdeniteOre" energyCost="32000">
@@ -3031,8 +3204,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMolybdenite" number="1" />
         <itemStack oreDictionary="crushedMolybdenum" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneMolybdeniteOre" energyCost="32000">
@@ -3042,8 +3215,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMolybdenite" number="1" />
         <itemStack oreDictionary="crushedMolybdenum" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="MolybdeniteOre" energyCost="32000">
@@ -3053,8 +3226,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMolybdenite" number="1" />
         <itemStack oreDictionary="crushedMolybdenum" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteMolybdeniteOre" energyCost="32000">
@@ -3064,8 +3237,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMolybdenite" number="1" />
         <itemStack oreDictionary="crushedMolybdenum" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteMolybdeniteOre" energyCost="32000">
@@ -3075,8 +3248,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMolybdenite" number="1" />
         <itemStack oreDictionary="crushedMolybdenum" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackFirestoneOre" energyCost="32000">
@@ -3086,8 +3259,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallFirestone" number="1" />
         <itemStack oreDictionary="crushedFirestone" number="1" />
-        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneFirestoneOre" energyCost="32000">
@@ -3097,8 +3270,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallFirestone" number="1" />
         <itemStack oreDictionary="crushedFirestone" number="1" />
-        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="FirestoneOre" energyCost="32000">
@@ -3108,8 +3281,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallFirestone" number="1" />
         <itemStack oreDictionary="crushedFirestone" number="1" />
-        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteFirestoneOre" energyCost="32000">
@@ -3119,8 +3292,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallFirestone" number="1" />
         <itemStack oreDictionary="crushedFirestone" number="1" />
-        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteFirestoneOre" energyCost="32000">
@@ -3130,8 +3303,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallFirestone" number="1" />
         <itemStack oreDictionary="crushedFirestone" number="1" />
-        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedFirestone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackSapphireOre" energyCost="32000">
@@ -3141,8 +3314,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSapphire" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSapphireOre" energyCost="32000">
@@ -3152,8 +3325,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSapphire" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SapphireOre" energyCost="32000">
@@ -3163,8 +3336,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSapphire" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSapphireOre" energyCost="32000">
@@ -3174,8 +3347,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSapphire" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSapphireOre" energyCost="32000">
@@ -3185,8 +3358,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSapphire" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGreenSapphire" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackPyropeOre" energyCost="32000">
@@ -3196,8 +3369,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrope" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstonePyropeOre" energyCost="32000">
@@ -3207,8 +3380,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrope" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="PyropeOre" energyCost="32000">
@@ -3218,8 +3391,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrope" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgranitePyropeOre" energyCost="32000">
@@ -3229,8 +3402,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrope" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgranitePyropeOre" energyCost="32000">
@@ -3240,8 +3413,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrope" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackWulfeniteOre" energyCost="32000">
@@ -3251,8 +3424,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallWulfenite" number="1" />
         <itemStack oreDictionary="crushedWulfenite" number="1" />
-        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneWulfeniteOre" energyCost="32000">
@@ -3262,8 +3435,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallWulfenite" number="1" />
         <itemStack oreDictionary="crushedWulfenite" number="1" />
-        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="WulfeniteOre" energyCost="32000">
@@ -3273,8 +3446,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallWulfenite" number="1" />
         <itemStack oreDictionary="crushedWulfenite" number="1" />
-        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteWulfeniteOre" energyCost="32000">
@@ -3284,8 +3457,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallWulfenite" number="1" />
         <itemStack oreDictionary="crushedWulfenite" number="1" />
-        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteWulfeniteOre" energyCost="32000">
@@ -3295,8 +3468,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallWulfenite" number="1" />
         <itemStack oreDictionary="crushedWulfenite" number="1" />
-        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedWulfenite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackPowelliteOre" energyCost="32000">
@@ -3306,8 +3479,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPowellite" number="1" />
         <itemStack oreDictionary="crushedPowellite" number="1" />
-        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstonePowelliteOre" energyCost="32000">
@@ -3317,8 +3490,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPowellite" number="1" />
         <itemStack oreDictionary="crushedPowellite" number="1" />
-        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="PowelliteOre" energyCost="32000">
@@ -3328,8 +3501,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPowellite" number="1" />
         <itemStack oreDictionary="crushedPowellite" number="1" />
-        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgranitePowelliteOre" energyCost="32000">
@@ -3339,8 +3512,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPowellite" number="1" />
         <itemStack oreDictionary="crushedPowellite" number="1" />
-        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgranitePowelliteOre" energyCost="32000">
@@ -3350,8 +3523,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPowellite" number="1" />
         <itemStack oreDictionary="crushedPowellite" number="1" />
-        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedPowellite" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackGraphiteOre" energyCost="32000">
@@ -3361,8 +3534,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGraphite" number="1" />
         <itemStack oreDictionary="dustCarbon" number="1" />
-        <itemStack oreDictionary="dustCarbon" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustCarbon" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneGraphiteOre" energyCost="32000">
@@ -3372,8 +3545,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGraphite" number="1" />
         <itemStack oreDictionary="dustCarbon" number="1" />
-        <itemStack oreDictionary="dustCarbon" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustCarbon" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="GraphiteOre" energyCost="32000">
@@ -3383,8 +3556,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGraphite" number="1" />
         <itemStack oreDictionary="dustCarbon" number="1" />
-        <itemStack oreDictionary="dustCarbon" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustCarbon" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteGraphiteOre" energyCost="32000">
@@ -3394,8 +3567,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGraphite" number="1" />
         <itemStack oreDictionary="dustCarbon" number="1" />
-        <itemStack oreDictionary="dustCarbon" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustCarbon" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteGraphiteOre" energyCost="32000">
@@ -3405,8 +3578,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGraphite" number="1" />
         <itemStack oreDictionary="dustCarbon" number="1" />
-        <itemStack oreDictionary="dustCarbon" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustCarbon" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustCarbon" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackGreenSapphireOre" energyCost="32000">
@@ -3416,8 +3589,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGreenSapphire" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneGreenSapphireOre" energyCost="32000">
@@ -3427,8 +3600,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGreenSapphire" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="GreenSapphireOre" energyCost="32000">
@@ -3438,8 +3611,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGreenSapphire" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteGreenSapphireOre" energyCost="32000">
@@ -3449,8 +3622,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGreenSapphire" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteGreenSapphireOre" energyCost="32000">
@@ -3460,8 +3633,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGreenSapphire" number="1" />
         <itemStack oreDictionary="crushedAluminium" number="1" />
-        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSapphire" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackMagnesiteOre" energyCost="32000">
@@ -3471,8 +3644,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMagnesite" number="1" />
         <itemStack oreDictionary="crushedMagnesium" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneMagnesiteOre" energyCost="32000">
@@ -3482,8 +3655,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMagnesite" number="1" />
         <itemStack oreDictionary="crushedMagnesium" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="MagnesiteOre" energyCost="32000">
@@ -3493,8 +3666,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMagnesite" number="1" />
         <itemStack oreDictionary="crushedMagnesium" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteMagnesiteOre" energyCost="32000">
@@ -3504,8 +3677,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMagnesite" number="1" />
         <itemStack oreDictionary="crushedMagnesium" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteMagnesiteOre" energyCost="32000">
@@ -3515,8 +3688,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMagnesite" number="1" />
         <itemStack oreDictionary="crushedMagnesium" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackCopperOre" energyCost="32000">
@@ -3526,8 +3699,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCopper" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="01511" />
       </output>
     </recipe>
     <recipe name="EndstoneCopperOre" energyCost="32000">
@@ -3537,8 +3710,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCopper" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="01511" />
       </output>
     </recipe>
     <recipe name="CopperOre" energyCost="32000">
@@ -3548,8 +3721,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCopper" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="01511" />
       </output>
     </recipe>
     <recipe name="RedgraniteCopperOre" energyCost="32000">
@@ -3559,8 +3732,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCopper" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="01511" />
       </output>
     </recipe>
     <recipe name="BlackgraniteCopperOre" energyCost="32000">
@@ -3570,8 +3743,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCopper" number="1" />
         <itemStack oreDictionary="crushedCobalt" number="1" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="01511" />
       </output>
     </recipe>
     <recipe name="NetherrackLithiumOre" energyCost="32000">
@@ -3581,8 +3754,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLithium" number="1" />
         <itemStack oreDictionary="crushedLithium" number="1" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneLithiumOre" energyCost="32000">
@@ -3592,8 +3765,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLithium" number="1" />
         <itemStack oreDictionary="crushedLithium" number="1" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="LithiumOre" energyCost="32000">
@@ -3603,8 +3776,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLithium" number="1" />
         <itemStack oreDictionary="crushedLithium" number="1" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteLithiumOre" energyCost="32000">
@@ -3614,8 +3787,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLithium" number="1" />
         <itemStack oreDictionary="crushedLithium" number="1" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteLithiumOre" energyCost="32000">
@@ -3625,8 +3798,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLithium" number="1" />
         <itemStack oreDictionary="crushedLithium" number="1" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLithium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLithium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackRedstoneOre" energyCost="32000">
@@ -3636,8 +3809,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRedstone" number="5" />
         <itemStack oreDictionary="crushedCinnabar" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneRedstoneOre" energyCost="32000">
@@ -3647,8 +3820,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRedstone" number="5" />
         <itemStack oreDictionary="crushedCinnabar" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedstoneOre" energyCost="32000">
@@ -3658,8 +3831,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRedstone" number="5" />
         <itemStack oreDictionary="crushedCinnabar" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteRedstoneOre" energyCost="32000">
@@ -3669,8 +3842,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRedstone" number="5" />
         <itemStack oreDictionary="crushedCinnabar" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteRedstoneOre" energyCost="32000">
@@ -3680,8 +3853,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallRedstone" number="5" />
         <itemStack oreDictionary="crushedCinnabar" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackBandedIronOre" energyCost="32000">
@@ -3691,8 +3864,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBandedIron" number="1" />
         <itemStack oreDictionary="crushedBandedIron" number="1" />
-        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneBandedIronOre" energyCost="32000">
@@ -3702,8 +3875,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBandedIron" number="1" />
         <itemStack oreDictionary="crushedBandedIron" number="1" />
-        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BandedIronOre" energyCost="32000">
@@ -3713,8 +3886,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBandedIron" number="1" />
         <itemStack oreDictionary="crushedBandedIron" number="1" />
-        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteBandedIronOre" energyCost="32000">
@@ -3724,8 +3897,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBandedIron" number="1" />
         <itemStack oreDictionary="crushedBandedIron" number="1" />
-        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteBandedIronOre" energyCost="32000">
@@ -3735,8 +3908,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBandedIron" number="1" />
         <itemStack oreDictionary="crushedBandedIron" number="1" />
-        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedBandedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackCinnabarOre" energyCost="32000">
@@ -3746,8 +3919,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCinnabar" number="1" />
         <itemStack oreDictionary="crushedRedstone" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneCinnabarOre" energyCost="32000">
@@ -3757,8 +3930,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCinnabar" number="1" />
         <itemStack oreDictionary="crushedRedstone" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="CinnabarOre" energyCost="32000">
@@ -3768,8 +3941,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCinnabar" number="1" />
         <itemStack oreDictionary="crushedRedstone" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteCinnabarOre" energyCost="32000">
@@ -3779,8 +3952,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCinnabar" number="1" />
         <itemStack oreDictionary="crushedRedstone" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteCinnabarOre" energyCost="32000">
@@ -3790,8 +3963,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallCinnabar" number="1" />
         <itemStack oreDictionary="crushedRedstone" number="1" />
-        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSulfur" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustGlowstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackUraniumOre" energyCost="32000">
@@ -3801,8 +3974,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallUranium" number="1" />
         <itemStack oreDictionary="crushedLead" number="1" />
-        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneUraniumOre" energyCost="32000">
@@ -3812,8 +3985,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallUranium" number="1" />
         <itemStack oreDictionary="crushedLead" number="1" />
-        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="UraniumOre" energyCost="32000">
@@ -3823,8 +3996,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallUranium" number="1" />
         <itemStack oreDictionary="crushedLead" number="1" />
-        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteUraniumOre" energyCost="32000">
@@ -3834,8 +4007,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallUranium" number="1" />
         <itemStack oreDictionary="crushedLead" number="1" />
-        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteUraniumOre" energyCost="32000">
@@ -3845,8 +4018,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallUranium" number="1" />
         <itemStack oreDictionary="crushedLead" number="1" />
-        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedThorium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedUranium235" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedThorium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackGlauconiteOre" energyCost="32000">
@@ -3856,8 +4029,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGlauconite" number="1" />
         <itemStack oreDictionary="crushedSodium" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneGlauconiteOre" energyCost="32000">
@@ -3867,8 +4040,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGlauconite" number="1" />
         <itemStack oreDictionary="crushedSodium" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="GlauconiteOre" energyCost="32000">
@@ -3878,8 +4051,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGlauconite" number="1" />
         <itemStack oreDictionary="crushedSodium" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteGlauconiteOre" energyCost="32000">
@@ -3889,8 +4062,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGlauconite" number="1" />
         <itemStack oreDictionary="crushedSodium" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteGlauconiteOre" energyCost="32000">
@@ -3900,8 +4073,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGlauconite" number="1" />
         <itemStack oreDictionary="crushedSodium" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedIron" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedIron" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackSaltpeterOre" energyCost="32000">
@@ -3911,8 +4084,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSaltpeter" number="4" />
         <itemStack oreDictionary="crushedSaltpeter" number="1" />
-        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSaltpeterOre" energyCost="32000">
@@ -3922,8 +4095,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSaltpeter" number="4" />
         <itemStack oreDictionary="crushedSaltpeter" number="1" />
-        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SaltpeterOre" energyCost="32000">
@@ -3933,8 +4106,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSaltpeter" number="4" />
         <itemStack oreDictionary="crushedSaltpeter" number="1" />
-        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSaltpeterOre" energyCost="32000">
@@ -3944,8 +4117,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSaltpeter" number="4" />
         <itemStack oreDictionary="crushedSaltpeter" number="1" />
-        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSaltpeterOre" energyCost="32000">
@@ -3955,8 +4128,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSaltpeter" number="4" />
         <itemStack oreDictionary="crushedSaltpeter" number="1" />
-        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSaltpeter" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackTinOre" energyCost="32000">
@@ -3966,8 +4139,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTin" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneTinOre" energyCost="32000">
@@ -3977,8 +4150,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTin" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="TinOre" energyCost="32000">
@@ -3988,8 +4161,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTin" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteTinOre" energyCost="32000">
@@ -3999,8 +4172,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTin" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteTinOre" energyCost="32000">
@@ -4010,8 +4183,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTin" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackMagnetiteOre" energyCost="32000">
@@ -4021,8 +4194,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMagnetite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneMagnetiteOre" energyCost="32000">
@@ -4032,8 +4205,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMagnetite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="MagnetiteOre" energyCost="32000">
@@ -4043,8 +4216,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMagnetite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteMagnetiteOre" energyCost="32000">
@@ -4054,8 +4227,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMagnetite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteMagnetiteOre" energyCost="32000">
@@ -4065,8 +4238,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMagnetite" number="1" />
         <itemStack oreDictionary="crushedIron" number="1" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackSiliconOre" energyCost="32000">
@@ -4076,8 +4249,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSilicon" number="1" />
         <itemStack oreDictionary="dustSiliconDioxide" number="1" />
-        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSiliconOre" energyCost="32000">
@@ -4087,8 +4260,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSilicon" number="1" />
         <itemStack oreDictionary="dustSiliconDioxide" number="1" />
-        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SiliconOre" energyCost="32000">
@@ -4098,8 +4271,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSilicon" number="1" />
         <itemStack oreDictionary="dustSiliconDioxide" number="1" />
-        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSiliconOre" energyCost="32000">
@@ -4109,8 +4282,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSilicon" number="1" />
         <itemStack oreDictionary="dustSiliconDioxide" number="1" />
-        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSiliconOre" energyCost="32000">
@@ -4120,8 +4293,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSilicon" number="1" />
         <itemStack oreDictionary="dustSiliconDioxide" number="1" />
-        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustSiliconDioxide" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackSpessartineOre" energyCost="32000">
@@ -4131,8 +4304,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSpessartine" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSpessartineOre" energyCost="32000">
@@ -4142,8 +4315,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSpessartine" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SpessartineOre" energyCost="32000">
@@ -4153,8 +4326,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSpessartine" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSpessartineOre" energyCost="32000">
@@ -4164,8 +4337,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSpessartine" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSpessartineOre" energyCost="32000">
@@ -4175,8 +4348,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSpessartine" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackBastnasiteOre" energyCost="32000">
@@ -4186,8 +4359,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBastnasite" number="1" />
         <itemStack oreDictionary="crushedNeodymium" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneBastnasiteOre" energyCost="32000">
@@ -4197,8 +4370,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBastnasite" number="1" />
         <itemStack oreDictionary="crushedNeodymium" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BastnasiteOre" energyCost="32000">
@@ -4208,8 +4381,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBastnasite" number="1" />
         <itemStack oreDictionary="crushedNeodymium" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteBastnasiteOre" energyCost="32000">
@@ -4219,8 +4392,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBastnasite" number="1" />
         <itemStack oreDictionary="crushedNeodymium" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteBastnasiteOre" energyCost="32000">
@@ -4230,8 +4403,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallBastnasite" number="1" />
         <itemStack oreDictionary="crushedNeodymium" number="1" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.1" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackGoldOre" energyCost="32000">
@@ -4241,8 +4414,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGold" number="1" />
         <itemStack oreDictionary="crushedCopper" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneGoldOre" energyCost="32000">
@@ -4252,8 +4425,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGold" number="1" />
         <itemStack oreDictionary="crushedCopper" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="GoldOre" energyCost="32000">
@@ -4263,8 +4436,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGold" number="1" />
         <itemStack oreDictionary="crushedCopper" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteGoldOre" energyCost="32000">
@@ -4274,8 +4447,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGold" number="1" />
         <itemStack oreDictionary="crushedCopper" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteGoldOre" energyCost="32000">
@@ -4285,8 +4458,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallGold" number="1" />
         <itemStack oreDictionary="crushedCopper" number="1" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedNickel" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedNickel" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackSoapstoneOre" energyCost="32000">
@@ -4296,8 +4469,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSoapstone" number="1" />
         <itemStack oreDictionary="crushedSoapstone" number="1" />
-        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneSoapstoneOre" energyCost="32000">
@@ -4307,8 +4480,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSoapstone" number="1" />
         <itemStack oreDictionary="crushedSoapstone" number="1" />
-        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="SoapstoneOre" energyCost="32000">
@@ -4318,8 +4491,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSoapstone" number="1" />
         <itemStack oreDictionary="crushedSoapstone" number="1" />
-        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteSoapstoneOre" energyCost="32000">
@@ -4329,8 +4502,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSoapstone" number="1" />
         <itemStack oreDictionary="crushedSoapstone" number="1" />
-        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteSoapstoneOre" energyCost="32000">
@@ -4340,8 +4513,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallSoapstone" number="1" />
         <itemStack oreDictionary="crushedSoapstone" number="1" />
-        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedSoapstone" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackLazuriteOre" energyCost="32000">
@@ -4351,8 +4524,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLazurite" number="6" />
         <itemStack oreDictionary="crushedSodalite" number="4" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneLazuriteOre" energyCost="32000">
@@ -4362,8 +4535,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLazurite" number="6" />
         <itemStack oreDictionary="crushedSodalite" number="4" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="LazuriteOre" energyCost="32000">
@@ -4373,8 +4546,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLazurite" number="6" />
         <itemStack oreDictionary="crushedSodalite" number="4" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteLazuriteOre" energyCost="32000">
@@ -4384,8 +4557,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLazurite" number="6" />
         <itemStack oreDictionary="crushedSodalite" number="4" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteLazuriteOre" energyCost="32000">
@@ -4395,8 +4568,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallLazurite" number="6" />
         <itemStack oreDictionary="crushedSodalite" number="4" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.33" />
-        <itemStack oreDictionary="crushedLapis" number="4" chance="0.1" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.06" />
+        <itemStack oreDictionary="crushedLapis" number="4" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackAlmandineOre" energyCost="32000">
@@ -4406,8 +4579,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAlmandine" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneAlmandineOre" energyCost="32000">
@@ -4417,8 +4590,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAlmandine" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="AlmandineOre" energyCost="32000">
@@ -4428,8 +4601,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAlmandine" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteAlmandineOre" energyCost="32000">
@@ -4439,8 +4612,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAlmandine" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteAlmandineOre" energyCost="32000">
@@ -4450,8 +4623,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallAlmandine" number="1" />
         <itemStack oreDictionary="crushedGarnetRed" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackMolybdenumOre" energyCost="32000">
@@ -4461,8 +4634,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMolybdenum" number="1" />
         <itemStack oreDictionary="crushedMolybdenum" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneMolybdenumOre" energyCost="32000">
@@ -4472,8 +4645,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMolybdenum" number="1" />
         <itemStack oreDictionary="crushedMolybdenum" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="MolybdenumOre" energyCost="32000">
@@ -4483,8 +4656,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMolybdenum" number="1" />
         <itemStack oreDictionary="crushedMolybdenum" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteMolybdenumOre" energyCost="32000">
@@ -4494,8 +4667,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMolybdenum" number="1" />
         <itemStack oreDictionary="crushedMolybdenum" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteMolybdenumOre" energyCost="32000">
@@ -4505,8 +4678,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMolybdenum" number="1" />
         <itemStack oreDictionary="crushedMolybdenum" number="1" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMolybdenum" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackOlivineOre" energyCost="32000">
@@ -4516,8 +4689,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallOlivine" number="1" />
         <itemStack oreDictionary="crushedPyrope" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneOlivineOre" energyCost="32000">
@@ -4527,8 +4700,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallOlivine" number="1" />
         <itemStack oreDictionary="crushedPyrope" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="OlivineOre" energyCost="32000">
@@ -4538,8 +4711,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallOlivine" number="1" />
         <itemStack oreDictionary="crushedPyrope" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteOlivineOre" energyCost="32000">
@@ -4549,8 +4722,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallOlivine" number="1" />
         <itemStack oreDictionary="crushedPyrope" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteOlivineOre" energyCost="32000">
@@ -4560,8 +4733,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallOlivine" number="1" />
         <itemStack oreDictionary="crushedPyrope" number="1" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedMagnesium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackPyrolusiteOre" energyCost="32000">
@@ -4571,8 +4744,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrolusite" number="1" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstonePyrolusiteOre" energyCost="32000">
@@ -4582,8 +4755,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrolusite" number="1" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="PyrolusiteOre" energyCost="32000">
@@ -4593,8 +4766,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrolusite" number="1" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgranitePyrolusiteOre" energyCost="32000">
@@ -4604,8 +4777,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrolusite" number="1" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgranitePyrolusiteOre" energyCost="32000">
@@ -4615,8 +4788,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPyrolusite" number="1" />
         <itemStack oreDictionary="crushedManganese" number="1" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedManganese" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedManganese" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackMonaziteOre" energyCost="32000">
@@ -4626,8 +4799,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMonazite" number="8" />
         <itemStack oreDictionary="crushedThorium" number="2" />
-        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.1" />
+        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneMonaziteOre" energyCost="32000">
@@ -4637,8 +4810,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMonazite" number="8" />
         <itemStack oreDictionary="crushedThorium" number="2" />
-        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.1" />
+        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.015" />
       </output>
     </recipe>
     <recipe name="MonaziteOre" energyCost="32000">
@@ -4648,8 +4821,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMonazite" number="8" />
         <itemStack oreDictionary="crushedThorium" number="2" />
-        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.1" />
+        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteMonaziteOre" energyCost="32000">
@@ -4659,8 +4832,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMonazite" number="8" />
         <itemStack oreDictionary="crushedThorium" number="2" />
-        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.1" />
+        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteMonaziteOre" energyCost="32000">
@@ -4670,8 +4843,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallMonazite" number="8" />
         <itemStack oreDictionary="crushedThorium" number="2" />
-        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.33" />
-        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.1" />
+        <itemStack oreDictionary="crushedNeodymium" number="2" chance="0.06" />
+        <itemStack oreDictionary="dustRareEarth" number="2" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackChalcopyriteOre" energyCost="32000">
@@ -4681,8 +4854,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallChalcopyrite" number="1" />
         <itemStack oreDictionary="crushedPyrite" number="1" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneChalcopyriteOre" energyCost="32000">
@@ -4692,8 +4865,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallChalcopyrite" number="1" />
         <itemStack oreDictionary="crushedPyrite" number="1" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="ChalcopyriteOre" energyCost="32000">
@@ -4703,8 +4876,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallChalcopyrite" number="1" />
         <itemStack oreDictionary="crushedPyrite" number="1" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteChalcopyriteOre" energyCost="32000">
@@ -4714,8 +4887,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallChalcopyrite" number="1" />
         <itemStack oreDictionary="crushedPyrite" number="1" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteChalcopyriteOre" energyCost="32000">
@@ -4725,8 +4898,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallChalcopyrite" number="1" />
         <itemStack oreDictionary="crushedPyrite" number="1" />
-        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedGold" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedCobalt" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedGold" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackIridiumOre" energyCost="32000">
@@ -4736,8 +4909,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIridium" number="1" />
         <itemStack oreDictionary="crushedPlatinum" number="1" />
-        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneIridiumOre" energyCost="32000">
@@ -4747,8 +4920,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIridium" number="1" />
         <itemStack oreDictionary="crushedPlatinum" number="1" />
-        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="IridiumOre" energyCost="32000">
@@ -4758,8 +4931,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIridium" number="1" />
         <itemStack oreDictionary="crushedPlatinum" number="1" />
-        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteIridiumOre" energyCost="32000">
@@ -4769,8 +4942,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIridium" number="1" />
         <itemStack oreDictionary="crushedPlatinum" number="1" />
-        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteIridiumOre" energyCost="32000">
@@ -4780,8 +4953,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallIridium" number="1" />
         <itemStack oreDictionary="crushedPlatinum" number="1" />
-        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedOsmium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackTetrahedriteOre" energyCost="32000">
@@ -4791,8 +4964,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTetrahedrite" number="1" />
         <itemStack oreDictionary="crushedAntimony" number="1" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneTetrahedriteOre" energyCost="32000">
@@ -4802,8 +4975,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTetrahedrite" number="1" />
         <itemStack oreDictionary="crushedAntimony" number="1" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="TetrahedriteOre" energyCost="32000">
@@ -4813,8 +4986,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTetrahedrite" number="1" />
         <itemStack oreDictionary="crushedAntimony" number="1" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteTetrahedriteOre" energyCost="32000">
@@ -4824,8 +4997,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTetrahedrite" number="1" />
         <itemStack oreDictionary="crushedAntimony" number="1" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteTetrahedriteOre" energyCost="32000">
@@ -4835,8 +5008,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallTetrahedrite" number="1" />
         <itemStack oreDictionary="crushedAntimony" number="1" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedZinc" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedZinc" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackEmeraldOre" energyCost="32000">
@@ -4846,8 +5019,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallEmerald" number="1" />
         <itemStack oreDictionary="crushedBeryllium" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneEmeraldOre" energyCost="32000">
@@ -4857,8 +5030,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallEmerald" number="1" />
         <itemStack oreDictionary="crushedBeryllium" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EmeraldOre" energyCost="32000">
@@ -4868,8 +5041,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallEmerald" number="1" />
         <itemStack oreDictionary="crushedBeryllium" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteEmeraldOre" energyCost="32000">
@@ -4879,8 +5052,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallEmerald" number="1" />
         <itemStack oreDictionary="crushedBeryllium" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteEmeraldOre" energyCost="32000">
@@ -4890,8 +5063,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallEmerald" number="1" />
         <itemStack oreDictionary="crushedBeryllium" number="1" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAluminium" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackStibniteOre" energyCost="32000">
@@ -4901,8 +5074,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallStibnite" number="1" />
         <itemStack oreDictionary="crushedAntimony" number="1" />
-        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstoneStibniteOre" energyCost="32000">
@@ -4912,8 +5085,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallStibnite" number="1" />
         <itemStack oreDictionary="crushedAntimony" number="1" />
-        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="StibniteOre" energyCost="32000">
@@ -4923,8 +5096,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallStibnite" number="1" />
         <itemStack oreDictionary="crushedAntimony" number="1" />
-        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgraniteStibniteOre" energyCost="32000">
@@ -4934,8 +5107,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallStibnite" number="1" />
         <itemStack oreDictionary="crushedAntimony" number="1" />
-        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgraniteStibniteOre" energyCost="32000">
@@ -4945,8 +5118,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallStibnite" number="1" />
         <itemStack oreDictionary="crushedAntimony" number="1" />
-        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedAntimony" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="NetherrackPitchblendeOre" energyCost="32000">
@@ -4956,8 +5129,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPitchblende" number="1" />
         <itemStack oreDictionary="crushedThorium" number="1" />
-        <itemStack oreDictionary="crushedUranium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedUranium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="EndstonePitchblendeOre" energyCost="32000">
@@ -4967,8 +5140,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPitchblende" number="1" />
         <itemStack oreDictionary="crushedThorium" number="1" />
-        <itemStack oreDictionary="crushedUranium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedUranium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="PitchblendeOre" energyCost="32000">
@@ -4978,8 +5151,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPitchblende" number="1" />
         <itemStack oreDictionary="crushedThorium" number="1" />
-        <itemStack oreDictionary="crushedUranium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedUranium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="RedgranitePitchblendeOre" energyCost="32000">
@@ -4989,8 +5162,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPitchblende" number="1" />
         <itemStack oreDictionary="crushedThorium" number="1" />
-        <itemStack oreDictionary="crushedUranium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedUranium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
     <recipe name="BlackgranitePitchblendeOre" energyCost="32000">
@@ -5000,8 +5173,8 @@ found in the core file.
       <output>
         <itemStack oreDictionary="dustSmallPitchblende" number="1" />
         <itemStack oreDictionary="crushedThorium" number="1" />
-        <itemStack oreDictionary="crushedUranium" number="1" chance="0.33" />
-        <itemStack oreDictionary="crushedLead" number="1" chance="0.1" />
+        <itemStack oreDictionary="crushedUranium" number="1" chance="0.06" />
+        <itemStack oreDictionary="crushedLead" number="1" chance="0.015" />
       </output>
     </recipe>
   </recipeGroup>
@@ -5010,14 +5183,17 @@ found in the core file.
     <grindingBall id="Flint" remove="true" />
     <grindingBall id="DarkSteelBall" remove="true" />
 
-    <grindingBall id="IronRound" grindingMultiplier="1.2" chanceMultiplier="1.25" powerMultiplier="0.85" durationRF="6000" >
-      <itemStack oreDictionary="roundIron" />
-    </grindingBall>
-    <grindingBall id="DarkSteelRound" grindingMultiplier="1.5" chanceMultiplier="2" powerMultiplier="0.7" durationRF="12000" >
+    <grindingBall id="DarkSteelRound" grindingMultiplier="1" chanceMultiplier="4" powerMultiplier="1.0" durationRF="11000" >
       <itemStack oreDictionary="roundDarkSteel" />
     </grindingBall>
-    <grindingBall id="TungstenSteelRound" grindingMultiplier="1.5" chanceMultiplier="2" powerMultiplier="0.7" durationRF="60000" >
-      <itemStack oreDictionary="roundTungstenSteel" />
+    <grindingBall id="TitaniumRound" grindingMultiplier="1.2" chanceMultiplier="7" powerMultiplier="1.5" durationRF="48000" >
+      <itemStack oreDictionary="roundTitanium" />
+    </grindingBall>
+    <grindingBall id="NaquadahAlloyRound" grindingMultiplier="1.4" chanceMultiplier="11" powerMultiplier="2.0" durationRF="192000" >
+      <itemStack oreDictionary="roundNaquadahAlloy" />
+    </grindingBall>
+    <grindingBall id="NeutroniumRound" grindingMultiplier="1.5" chanceMultiplier="14" powerMultiplier="4.0" durationRF="64000000" >
+      <itemStack oreDictionary="roundNeutronium" />
     </grindingBall>
   </grindingBalls>
 


### PR DESCRIPTION
Lowers base chance rates, increases grinding ball chance rates proportionally, nerfs grinding ball material/power usage

Now requires dark steel to nearly match previous non-grinding ball rates, dark steel/titanium/naquadah alloy/neutronium new grinding ball tiers.