### PR TITLE
Adding (warded) jars back to bibliocraft potion shelves

### DIFF
--- a/config/BiblioCraft.cfg
+++ b/config/BiblioCraft.cfg
@@ -81,7 +81,7 @@ general {
     S:AdditionalDiscs=disc, disk
 
     # These are keywords that add additional support for more types of potions and items. Add more keyworks if you wish to allow more types of items to be displayed.
-    S:AdditionalPotions=essence, mead, bottle, test, element, molecule, can, capsule, cell, catalyst, ambrosia, honey pot, dissipation, vial, juice
+    S:AdditionalPotions=essence, mead, bottle, test, element, molecule, can, capsule, cell, catalyst, ambrosia, honey pot, dissipation, vial, juice, jar
 
     # These are the names of additional tools that can be added to the Tool Rack. Added keywords will allow additional items to be placed on this block.
     S:AdditionalTools=sprayer, wand, rod, scepter, wrench, screwdriver, meter, handsaw, gun, cutter, scoop, soldering, painter, reader, shovel, grafter, pickaxe, pipette, magnifying, sword, axe, hammer, saw


### PR DESCRIPTION
Not sure when we lost this, but I don't see any reason not to add this back.