### PR TITLE
replace yellorium with uranium

### DIFF
--- a/config/BigReactors/BigReactors.cfg
+++ b/config/BigReactors/BigReactors.cfg
@@ -2,7 +2,7 @@
 
 compatibility {
     # If true, automatically adds all unregistered ingots found as clonesof standard yellorium fuel
-    B:autoAddUranium=false
+    B:autoAddUranium=true
 }
 
 
@@ -33,7 +33,7 @@ recipes {
     B:registerCoalForSmelting=false
     B:registerGraphiteCharcoalCraftingRecipes=false
     B:registerGraphiteCoalCraftingRecipes=false
-    B:registerYelloriteSmeltToUranium=false
+    B:registerYelloriteSmeltToUranium=true
     B:registerYelloriumAsUranium=false
     B:requireObsidianGlass=false
     B:requireSteelInsteadOfIron=false
@@ -41,7 +41,7 @@ recipes {
 
 
 worldgen {
-    B:GenerateYelloriteOre=true
+    B:GenerateYelloriteOre=false
     I:MaxYelloriteClustersPerChunk=5
     I:MaxYelloriteOrePerCluster=10
     I:YelloriteDimensionBlacklist <
@@ -49,7 +49,7 @@ worldgen {
     I:YelloriteMaxY=50
     I:dimensionWhitelist <
      >
-    B:enableWorldGen=true
+    B:enableWorldGen=false
     B:enableWorldGenInNegativeDims=false
     B:enableWorldRegeneration=false
     I:userWorldGenVersion=0

--- a/scripts/bigreactors.zs
+++ b/scripts/bigreactors.zs
@@ -17,6 +17,7 @@ var plateStainlessSteel = <ore:plateStainlessSteel>;
 var plateSteel = <ore:plateSteel>;
 var plateTungstenSteel = <ore:plateTungstenSteel>;
 var reactorPowerTap = <ore:reactorPowerTap>;
+var comparator = <minecraft:comparator>;
 
 # BigReactors recipes we're changing
 var itemFuelRodYellorium = <BigReactors:YelloriumFuelRod>;
@@ -33,6 +34,7 @@ var itemTurbineHousing = <BigReactors:BRTurbinePart>;
 var itemTurbineRotorBearing = <BigReactors:BRTurbinePart:4>;
 var itemTurbineRotorBlade = <BigReactors:BRTurbineRotorPart:1>;
 var itemTurbineRotorShaft = <BigReactors:BRTurbineRotorPart>;
+var itemReactorMonitor = <IC2NuclearControl:NC-BRinfoFetch>;
 
 ###############################
 
@@ -134,6 +136,20 @@ recipes.addShaped(itemTurbineRotorBearing, [
 	[itemTurbineHousing, itemTurbineRotorShaft, itemTurbineHousing],
 	[itemDiamond, gearDiamond, itemDiamond],
 	[itemTurbineHousing, itemTurbineRotorShaft, itemTurbineHousing]]);
+
+# Reactor Monitor
+recipes.remove(itemReactorMonitor);
+recipes.addShaped(itemReactorMonitor, [
+	[itemReactorCasing, dustRedstone, itemReactorCasing],
+	[ingotUranium, comparator, ingotUranium],
+	[itemReactorCasing, dustRedstone, itemReactorCasing]]);
+recipes.addShaped(itemReactorMonitor, [
+	[itemReactorCasing, dustRedstone, itemReactorCasing],
+	[ingotYellorium, comparator, ingotYellorium],
+	[itemReactorCasing, dustRedstone, itemReactorCasing]]);
+
+# Yellorium Ingot
+furnace.addRecipe(<gregtech:gt.metaitem.01:11098>, ingotYellorium);
 
 # Reactor Power Tap
 reactorPowerTap.addTooltip(format.red(format.bold("This item is DISABLED!")));

--- a/scripts/bigreactors.zs
+++ b/scripts/bigreactors.zs
@@ -44,20 +44,12 @@ recipes.addShaped(itemFuelRodYellorium, [
 	[plateSteel, ingotGraphite, plateSteel],
 	[plateStainlessSteel, ingotUranium, plateStainlessSteel],
 	[plateSteel, ingotGraphite, plateSteel]]);
-recipes.addShaped(itemFuelRodYellorium, [
-	[plateSteel, ingotGraphite, plateSteel],
-	[plateStainlessSteel, ingotYellorium, plateStainlessSteel],
-	[plateSteel, ingotGraphite, plateSteel]]);
 	
 # Reactor Casing
 recipes.remove(itemReactorCasing);
 recipes.addShaped(itemReactorCasing * 4, [
 	[plateSteel, ingotGraphite, plateSteel],
 	[ingotGraphite, ingotUranium, ingotGraphite],
-	[plateSteel, ingotGraphite, plateSteel]]);
-recipes.addShaped(itemReactorCasing * 4, [
-	[plateSteel, ingotGraphite, plateSteel],
-	[ingotGraphite, ingotYellorium, ingotGraphite],
 	[plateSteel, ingotGraphite, plateSteel]]);
 
 # Reactor Glass
@@ -71,10 +63,6 @@ recipes.addShaped(itemReactorController, [
 	[itemReactorCasing, plateStainlessSteel, itemReactorCasing],
 	[ingotUranium, itemDiamond, ingotUranium],
 	[itemReactorCasing, plateStainlessSteel, itemReactorCasing]]);
-recipes.addShaped(itemReactorController, [
-	[itemReactorCasing, plateStainlessSteel, itemReactorCasing],
-	[ingotYellorium, itemDiamond, ingotYellorium],
-	[itemReactorCasing, plateStainlessSteel, itemReactorCasing]]);
 	
 # Reactor Control Rod
 recipes.remove(itemReactorControlRod);
@@ -82,10 +70,6 @@ recipes.addShaped(itemReactorControlRod, [
 	[itemReactorCasing, ingotGraphite, itemReactorCasing],
 	[ingotGraphite, dustRedstone, ingotGraphite],
 	[itemReactorCasing, ingotUranium, itemReactorCasing]]);
-recipes.addShaped(itemReactorControlRod, [
-	[itemReactorCasing, ingotGraphite, itemReactorCasing],
-	[ingotGraphite, dustRedstone, ingotGraphite],
-	[itemReactorCasing, ingotYellorium, itemReactorCasing]]);
 	
 # Cyanite Rercprocessor
 recipes.remove(itemReprocessorCyanite);
@@ -142,10 +126,6 @@ recipes.remove(itemReactorMonitor);
 recipes.addShaped(itemReactorMonitor, [
 	[itemReactorCasing, dustRedstone, itemReactorCasing],
 	[ingotUranium, comparator, ingotUranium],
-	[itemReactorCasing, dustRedstone, itemReactorCasing]]);
-recipes.addShaped(itemReactorMonitor, [
-	[itemReactorCasing, dustRedstone, itemReactorCasing],
-	[ingotYellorium, comparator, ingotYellorium],
 	[itemReactorCasing, dustRedstone, itemReactorCasing]]);
 
 # Yellorium Ingot

--- a/scripts/bigreactors.zs
+++ b/scripts/bigreactors.zs
@@ -9,6 +9,7 @@ var glass = <minecraft:glass>;
 var ingotCyanite = <ore:ingotCyanite>;
 var ingotGraphite = <ore:ingotGraphite>;
 var ingotYellorium = <ore:ingotYellorium>;
+var ingotUranium = <ore:ingotUranium>;
 var itemDiamond = <minecraft:diamond>;
 var itemPiston = <ore:craftingPiston>;
 var itemQuartzNether = <ore:craftingQuartz>;
@@ -22,7 +23,9 @@ var itemFuelRodYellorium = <BigReactors:YelloriumFuelRod>;
 var itemPortTurbineFluid = <BigReactors:BRTurbinePart:3>;
 var itemReactorCasing = <BigReactors:BRReactorPart>;
 var itemReactorController = <BigReactors:BRReactorPart:1>;
+var itemReactorControlRod = <BigReactors:BRReactorPart:2>;
 var itemReactorGlass = <BigReactors:BRMultiblockGlass>;
+var itemReactorRedNetPort = <BigReactors:BRReactorPart:6>;
 var itemReprocessorCyanite = <BigReactors:BRDevice>;
 var itemTurbineController = <BigReactors:BRTurbinePart:1>;
 var itemTurbineGlass = <BigReactors:BRMultiblockGlass:1>;
@@ -37,11 +40,19 @@ var itemTurbineRotorShaft = <BigReactors:BRTurbineRotorPart>;
 recipes.remove(itemFuelRodYellorium);
 recipes.addShaped(itemFuelRodYellorium, [
 	[plateSteel, ingotGraphite, plateSteel],
+	[plateStainlessSteel, ingotUranium, plateStainlessSteel],
+	[plateSteel, ingotGraphite, plateSteel]]);
+recipes.addShaped(itemFuelRodYellorium, [
+	[plateSteel, ingotGraphite, plateSteel],
 	[plateStainlessSteel, ingotYellorium, plateStainlessSteel],
 	[plateSteel, ingotGraphite, plateSteel]]);
 	
 # Reactor Casing
 recipes.remove(itemReactorCasing);
+recipes.addShaped(itemReactorCasing * 4, [
+	[plateSteel, ingotGraphite, plateSteel],
+	[ingotGraphite, ingotUranium, ingotGraphite],
+	[plateSteel, ingotGraphite, plateSteel]]);
 recipes.addShaped(itemReactorCasing * 4, [
 	[plateSteel, ingotGraphite, plateSteel],
 	[ingotGraphite, ingotYellorium, ingotGraphite],
@@ -56,8 +67,23 @@ recipes.addShaped(itemReactorGlass, [
 recipes.remove(itemReactorController);
 recipes.addShaped(itemReactorController, [
 	[itemReactorCasing, plateStainlessSteel, itemReactorCasing],
+	[ingotUranium, itemDiamond, ingotUranium],
+	[itemReactorCasing, plateStainlessSteel, itemReactorCasing]]);
+recipes.addShaped(itemReactorController, [
+	[itemReactorCasing, plateStainlessSteel, itemReactorCasing],
 	[ingotYellorium, itemDiamond, ingotYellorium],
 	[itemReactorCasing, plateStainlessSteel, itemReactorCasing]]);
+	
+# Reactor Control Rod
+recipes.remove(itemReactorControlRod);
+recipes.addShaped(itemReactorControlRod, [
+	[itemReactorCasing, ingotGraphite, itemReactorCasing],
+	[ingotGraphite, dustRedstone, ingotGraphite],
+	[itemReactorCasing, ingotUranium, itemReactorCasing]]);
+recipes.addShaped(itemReactorControlRod, [
+	[itemReactorCasing, ingotGraphite, itemReactorCasing],
+	[ingotGraphite, dustRedstone, ingotGraphite],
+	[itemReactorCasing, ingotYellorium, itemReactorCasing]]);
 	
 # Cyanite Rercprocessor
 recipes.remove(itemReprocessorCyanite);
@@ -111,3 +137,6 @@ recipes.addShaped(itemTurbineRotorBearing, [
 
 # Reactor Power Tap
 reactorPowerTap.addTooltip(format.red(format.bold("This item is DISABLED!")));
+
+# Reactor RedNet Port
+itemReactorRedNetPort.addTooltip(format.red(format.bold("This item is DISABLED!")));


### PR DESCRIPTION
I don't think it makes alot of sense to use yellorium for the big reactors especially considering that yellorium ore is basically uran and doesn't spawn like all others ores in big veins.
This will disable yellorium ore generation and enable the use of uranium in big reactors and in big reactor recipes.