### PR TITLE
Allow Industrial Credits in Compacting Drawer

### DIFF
--- a/scripts/storagedrawers.zs
+++ b/scripts/storagedrawers.zs
@@ -33,3 +33,5 @@ mods.storagedrawers.OreDictionaryBlacklist.add("itemCertusQuartz");
 # Credits in Compacting Drawer
 mods.storagedrawers.Compaction.add(<IC2:itemCoin>, <gregtech:gt.metaitem.01:32011>, 8);
 mods.storagedrawers.Compaction.add(<gregtech:gt.metaitem.01:32013>, <IC2:itemCoin>, 8);
+
+drawerCompacting.addTooltip("Also stores Industrial Credits");

--- a/scripts/storagedrawers.zs
+++ b/scripts/storagedrawers.zs
@@ -29,3 +29,7 @@ recipes.addShaped(drawerCompacting, [
 mods.storagedrawers.OreDictionaryBlacklist.add("craftingQuartz");
 mods.storagedrawers.OreDictionaryBlacklist.add("itemNetherQuartz");
 mods.storagedrawers.OreDictionaryBlacklist.add("itemCertusQuartz");
+
+# Credits in Compacting Drawer
+mods.storagedrawers.Compaction.add(<IC2:itemCoin>, <gregtech:gt.metaitem.01:32011>, 8);
+mods.storagedrawers.Compaction.add(<gregtech:gt.metaitem.01:32013>, <IC2:itemCoin>, 8);


### PR DESCRIPTION
A minor convenience, especially given that the Drawer isn't as useful for storing metals due to Blocks being made in a Compressor and Nuggets being made in a Furnace.