### PR TITLE
change item buffer recipe

### DIFF
--- a/scripts/enderio.zs
+++ b/scripts/enderio.zs
@@ -267,9 +267,9 @@ recipes.addShaped(probeConduit, [
 	[plateSilicon, conduitRedstoneInsulated, plateSilicon]]);
 recipes.remove(itemBuffer);
 recipes.addShaped(itemBuffer, [
-	[itemIngotIron, ingotSteel, itemIngotIron],
-	[ingotSteel, chest, ingotSteel],
-	[itemIngotIron, ingotSteel, itemIngotIron]]);
+	[plateSteel, conduitItem, plateSteel],
+	[conduitItem, chest, conduitItem],
+	[plateSteel, conduitItem, plateSteel]]);
 recipes.remove(paintingMachine);
 recipes.addShaped(paintingMachine, [
 	[netherQuartz, netherQuartz, netherQuartz],


### PR DESCRIPTION
The item buffer is basically a item conduit with a 9 slot inventory that can extract 1 full stack at a time and it doesn't make sense that you can make this long before you can make the item conduits.

before:
<img src="http://i.imgur.com/YmZh7lw.jpg">
after:
<img src="http://i.imgur.com/jJTkB8H.jpg">