### PR TITLE
prevent moving chevrons

### DIFF
--- a/config/SGCraft.cfg
+++ b/config/SGCraft.cfg
@@ -59,6 +59,7 @@ stargate {
     I:secondsToStayOpen=450
     D:soundVolume=1.0
     B:transparency=false
+    B:variableChevronPositions=false
 }
 
 


### PR DESCRIPTION
This stops chevrons from moving. Seriously they are fixed in position they could never ever move in the series.
<img src="https://i.imgur.com/fPgZFbC.gif"/>