### PR TITLE
Update GUIDE_Pyrolyse_Oven.json

### DIFF
--- a/config/enchiridion/books/GUIDE_Pyrolyse_Oven.json
+++ b/config/enchiridion/books/GUIDE_Pyrolyse_Oven.json
@@ -18,7 +18,7 @@
         {
           "type": "FeatureText",
           "properties": {
-            "text": "Pyrolyse Oven is fast multiblock machine used for creating:\n- Charcoal and Creosote\n- Heavy Oil\n- Biomass\n\nSpeed can be boosted by providing Nitrogen Gas.",
+            "text": "Pyrolyse Oven is fast multiblock machine used for creating:\n- Charcoal and Creosote*\n- Heavy Oil\n- Biomass\n\n*Speed can be boosted by providing Nitrogen Gas.",
             "wrap": 0,
             "size": 1.0,
             "color": "FF555555",


### PR DESCRIPTION
Nitrogen boost only applies to charcoal/creosote production, not the others.