### PR TITLE
add capacitor recipes with lithium and sodium batteries

### DIFF
--- a/scripts/opencomputers.zs
+++ b/scripts/opencomputers.zs
@@ -6,15 +6,30 @@ import mods.ic2.Macerator;
 
 # Aliases
 
-var chamelium       = <OpenComputers:item:96>;
-var chameliumBlock  = <OpenComputers:chameliumBlock>;
+var chamelium        = <OpenComputers:item:96>;
+var chameliumBlock   = <OpenComputers:chameliumBlock>;
+val capacitor        = <OpenComputers:capacitor>;
+val wrench           = <ore:craftingToolWrench>;
+val pcb              = <PneumaticCraft:printedCircuitBoard>;
+val transistor       = <OpenComputers:item:23>;
+val LVmachinecasing  = <gregtech:gt.blockcasings:1>;
+val MVbatterySodium  = <gregtech:gt.metaitem.01:32529>;
+val MVbatteryLithium = <gregtech:gt.metaitem.01:32528>;
 
 # Recipe Tweaks
 
 recipes.removeShaped(chameliumBlock);
 recipes.removeShapeless(chamelium);
 Compressor.addRecipe(chameliumBlock, chamelium * 9);
-Macerator.addRecipe( chamelium * 9, chameliumBlock);
+Macerator.addRecipe(chamelium * 9, chameliumBlock);
+recipes.addShaped(capacitor, [
+	[MVbatterySodium, null, MVbatterySodium],
+	[LVmachinecasing, transistor, LVmachinecasing],
+	[pcb, wrench, pcb]]);
+recipes.addShaped(capacitor, [
+	[null, MVbatteryLithium, null],
+	[LVmachinecasing, transistor, LVmachinecasing],
+	[pcb, wrench, pcb]]);
 
 # Tooltips/Removal
 recipes.remove(<OpenComputers:item:30>);


### PR DESCRIPTION
It doesn't really make sense to only have the capacitor recipe with the medium cadmium battery (300k eu).
This adds recipes for the sodium and lithium battery too.
Medium lithium battery has 400k eu so its not a problem.
Medium sodium battery only has 200k eu which is why I put two of those batteries into the recipe.